### PR TITLE
Add CANdle LED subsystem (Shooter state feedback)

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -146,4 +146,29 @@ public final class Constants {
     public static final double TARGET_TIMEOUT_SECONDS = 0.5;
   }
 
+  // =========================================================
+  // LEDs
+  // =========================================================
+  public static final class Led {
+    private Led() {}
+
+    /** CANdle device ID */
+    public static final int CANDLE_ID = 11;
+
+    /** CAN bus name for the CANdle (typically "canivore") */
+    public static final String CAN_BUS_NAME = "canivore";
+
+    /** WS2811 logical segments per meter */
+    public static final int SEGMENTS_PER_METER = 20;
+
+    /** WS2811 physical LEDs per logical segment */
+    public static final int LEDS_PER_SEGMENT = 36;
+
+    /** Total strip length in meters */
+    public static final int STRIP_LENGTH_METERS = 1;
+
+    /** Total number of logical addressable segments */
+    public static final int LOGICAL_LED_COUNT = SEGMENTS_PER_METER * STRIP_LENGTH_METERS;
+  }
+
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -13,6 +13,7 @@ import choreo.auto.AutoChooser;
 import choreo.auto.AutoFactory;
 
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
@@ -32,6 +33,7 @@ import frc.robot.subsystems.shooter.ShooterIO;
 import frc.robot.subsystems.shooter.ShooterIOSim;
 import frc.robot.subsystems.shooter.ShooterIOHardware;
 import frc.robot.subsystems.shooter.ShooterSubsystem;
+import frc.robot.subsystems.led.LedSubsystem;
 import frc.robot.subsystems.vision.VisionIO;
 import frc.robot.subsystems.vision.VisionIOLimelight;
 import frc.robot.subsystems.vision.VisionIOSim;
@@ -57,6 +59,8 @@ public class RobotContainer {
     private final CommandXboxController joystick = new CommandXboxController(0);
 
     public final CommandSwerveDrivetrain drivetrain = TunerConstants.createDrivetrain();
+    private final ShooterSubsystem shooter;
+    private final LedSubsystem ledSubsystem;
 
     /* Path follower */
     private final AutoFactory autoFactory;
@@ -64,6 +68,10 @@ public class RobotContainer {
     private final AutoChooser autoChooser = new AutoChooser();
 
     public RobotContainer() {
+        ShooterIO shooterIO = RobotBase.isReal() ? new ShooterIOHardware() : new ShooterIOSim();
+        shooter = new ShooterSubsystem(shooterIO);
+        ledSubsystem = new LedSubsystem(shooter);
+
         autoFactory = drivetrain.createAutoFactory();
         autoRoutines = new AutoRoutines(autoFactory);
 

--- a/src/main/java/frc/robot/subsystems/led/LedSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/led/LedSubsystem.java
@@ -1,0 +1,59 @@
+package frc.robot.subsystems.led;
+
+import com.ctre.phoenix6.hardware.CANdle;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants;
+import frc.robot.subsystems.shooter.ShooterSubsystem;
+import frc.robot.subsystems.shooter.ShooterSubsystem.ShooterState;
+
+/**
+ * LED subsystem driven by a CTRE CANdle for WS2811 strip control.
+ *
+ * The WS2811 COB strip is addressed as logical segments (20 per meter).
+ * Colors are applied per segment, not per physical LED.
+ */
+public class LedSubsystem extends SubsystemBase {
+    private static final LedColor IDLE_COLOR = new LedColor(0, 0, 0);
+    private static final LedColor SPINUP_COLOR = new LedColor(255, 140, 0);
+    private static final LedColor READY_COLOR = new LedColor(0, 255, 0);
+    private static final LedColor EJECT_COLOR = new LedColor(255, 0, 0);
+
+    private final CANdle candle;
+    private final ShooterSubsystem shooter;
+    private final int ledCount;
+
+    private LedColor lastColor = IDLE_COLOR;
+
+    public LedSubsystem(ShooterSubsystem shooter) {
+        this.shooter = shooter;
+        this.candle = new CANdle(Constants.Led.CANDLE_ID, Constants.Led.CAN_BUS_NAME);
+        this.ledCount = Math.max(1, Constants.Led.LOGICAL_LED_COUNT);
+        setSolidColor(IDLE_COLOR);
+    }
+
+    @Override
+    public void periodic() {
+        LedColor desiredColor = getShooterColor();
+        if (!desiredColor.equals(lastColor)) {
+            setSolidColor(desiredColor);
+        }
+    }
+
+    private LedColor getShooterColor() {
+        ShooterState state = shooter.getState();
+        return switch (state) {
+            case IDLE -> IDLE_COLOR;
+            case SPINUP -> SPINUP_COLOR;
+            case READY -> READY_COLOR;
+            case EJECT -> EJECT_COLOR;
+        };
+    }
+
+    private void setSolidColor(LedColor color) {
+        candle.setLEDs(color.red(), color.green(), color.blue(), 0, 0, ledCount);
+        lastColor = color;
+    }
+
+    private record LedColor(int red, int green, int blue) {}
+}


### PR DESCRIPTION
### Motivation
- Provide visual feedback for shooter state using a 12V WS2811 COB strip controlled by a CTRE CANdle so operators can quickly see shooter readiness. 
- Treat the WS2811 strip as logical segments (20 per meter, 36 LEDs per segment) rather than individual LEDs to match hardware constraints. 
- Integrate LED control with existing shooter logic so colors reflect the `ShooterSubsystem` state (IDLE / SPINUP / READY / EJECT).

### Description
- Add LED-related constants in `Constants.java` under a new `Led` class for `CANDLE_ID`, `CAN_BUS_NAME`, `SEGMENTS_PER_METER`, `LEDS_PER_SEGMENT`, and `LOGICAL_LED_COUNT`.
- Add a new `LedSubsystem` (`src/main/java/frc/robot/subsystems/led/LedSubsystem.java`) that uses `com.ctre.phoenix6.hardware.CANdle` and sets solid colors per logical segment based on the `ShooterSubsystem` state.
- Wire the new subsystem into `RobotContainer.java` by constructing a `ShooterSubsystem` with either `ShooterIOHardware` or `ShooterIOSim` via `RobotBase.isReal()` and creating `LedSubsystem` with the shooter instance.
- Define mapping colors for states (`IDLE`, `SPINUP`, `READY`, `EJECT`) and update the strip via `CANdle.setLEDs(...)` only when the desired color changes.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ef8f8f5c832a97d936b8719c065a)