### PR TITLE
docs: align controller-reference with RobotContainer bindings

### DIFF
--- a/src/main/java/frc/robot/docs/controller-reference.md
+++ b/src/main/java/frc/robot/docs/controller-reference.md
@@ -1,6 +1,6 @@
 # Controller Reference
 
-Quick reference for Xbox controller bindings used to operate the robot.
+Quick reference for Xbox controller bindings configured in `RobotContainer.java`.
 
 ---
 
@@ -8,254 +8,117 @@ Quick reference for Xbox controller bindings used to operate the robot.
 
 | Port | Controller | Purpose |
 |------|------------|---------|
-| 0 | Driver | Drivetrain movement and field-centric controls |
-| 1 | Operator | Mechanisms (shooter, intake, indexer, climber) |
+| 0 | Driver | Drivetrain movement and all currently active mechanism controls |
+| 1 | Operator | Reserved / currently unused in bindings |
 
 ---
 
 ## Driver Controller (Port 0)
 
-Controls the drivetrain movement and field-centric orientation.
+Controls drivetrain movement plus shooter, intake, and climber actions.
 
 ### Joysticks
 
 | Input | Function | Details |
 |-------|----------|---------|
 | **Left Stick** | Translate | Forward/backward (Y-axis), Left/right (X-axis) |
-| **Right Stick** | Rotate | Rotate robot (X-axis) |
+| **Right Stick (X)** | Rotate | Rotational rate command |
 
-- **Control Mode:** Field-centric drive (relative to field, not robot)
-- **Deadband:** 10% on both translation and rotation
-- **Max Speed:** 100% of robot top speed
-- **Max Angular Rate:** 0.75 rotations per second
+- **Control mode:** Field-centric drive
+- **Deadband:** 10% on translation and rotation
+- **Max angular rate:** 0.75 rotations/second
 
-### Buttons
+### Buttons and Triggers
 
-| Button | Function | Type | Details |
-|--------|----------|------|---------|
-| **A** | Brake | Hold | Lock wheels in X pattern (defensive position) |
-| **B** | Point Wheels | Hold | Point wheels at left joystick direction (testing) |
-| **Left Bumper** | Reset Heading | Press | Reset field-centric heading to current direction |
+| Input | Function | Type | Details |
+|-------|----------|------|---------|
+| **Start** | Reset heading | Press | Reseed field-centric heading |
+| **Right Trigger (> 50%)** | Full close-shot sequence | Hold | Runs shooter + indexer close-shot sequence while held |
+| **A** | Close shot preset | Press | Sets shooter to close-shot state |
+| **X** | Far shot preset | Press | Sets shooter to far-shot state |
+| **B** | Pass shot preset | Press | Sets shooter to pass-shot state |
+| **POV Up** | Shooter eject | Press | Reverse/eject from shooter for 1 second |
+| **Left Trigger (> 50%)** | Intake run | Hold | Runs intake command while held |
+| **Left Bumper** | Intake jam clear | Press | Executes intake stop-jam action |
+| **POV Right** | Climber extend | Hold | Extends climber arm while held |
+| **POV Left** | Climber retract | Hold | Retracts climber arm while held |
 
-### D-Pad (POV)
+### Currently Unbound / Disabled in Code
 
-| Direction | Function | Type | Details |
-|-----------|----------|------|---------|
-| **Up** | Slow Forward | Hold | Drive forward at 0.5 m/s (robot-centric) |
-| **Down** | Slow Backward | Hold | Drive backward at 0.5 m/s (robot-centric) |
+The following mappings are present as comments in `RobotContainer.java` and are **not active**:
 
-### SysId Routines (Advanced Testing)
-
-| Combination | Function | Details |
-|-------------|----------|---------|
-| **Back + Y** | Dynamic Forward | SysId characterization routine |
-| **Back + X** | Dynamic Reverse | SysId characterization routine |
-| **Start + Y** | Quasistatic Forward | SysId characterization routine |
-| **Start + X** | Quasistatic Reverse | SysId characterization routine |
-
-> **Note:** SysId routines are for system identification and characterization. Only use during testing sessions.
+- **A (driver):** Swerve brake mode
+- **B (driver):** Point wheels to stick direction
+- **POV Up/Down (driver drivetrain):** Slow robot-centric forward/backward drive
+- **Right Bumper (driver):** Indexer feed
+- **POV Down (driver):** Indexer eject
+- **Climber preset extend/retract and stop bindings**
+- **All SysId button combinations**
 
 ---
 
 ## Operator Controller (Port 1)
 
-Controls all robot mechanisms including shooter, intake, indexer, and climber.
-
-### Shooter Controls
-
-| Input | Function | Type | Details |
-|-------|----------|------|---------|
-| **Right Trigger** | Spin Up Shooter | Hold | Pre-rev shooter wheels (hold > 50%) |
-| **Y** | Close Shot | Press | Prepare shooter for close-range shot |
-| **X** | Far Shot | Press | Prepare shooter for far-range shot |
-| **B** | Idle Shooter | Press | Stop shooter and return to idle |
-| **A** | Full Shoot Sequence | Press | Complete close shot + feed + idle sequence |
-| **POV Up** | Eject from Shooter | Press | Reverse shooter for 1 second (clear jams) |
-
-### Indexer Controls
-
-| Input | Function | Type | Details |
-|-------|----------|------|---------|
-| **Right Bumper** | Feed to Shooter | Hold | Feed game piece from indexer to shooter |
-| **POV Down** | Eject from Indexer | Press | Reverse indexer for 1 second (clear jams) |
-
-### Intake Controls
-
-| Input | Function | Type | Details |
-|-------|----------|------|---------|
-| **Left Trigger** | Run Intake | Hold | Activate intake to collect game pieces (hold > 50%) |
-| **Left Bumper** | Stop Jam | Press | Quick reverse to clear intake jams |
-
-### Climber Controls
-
-| Input | Function | Type | Details |
-|-------|----------|------|---------|
-| **POV Right** | Extend Arm | Hold | Extend climber arm |
-| **POV Left** | Retract Arm | Hold | Retract climber arm |
-| **Start** | Stop Climber | Press | Stop all climber movement |
+No active bindings are currently configured for the operator controller in `configureBindings()`.
 
 ---
 
-## Button Layout Reference
-
-### Xbox Controller Diagram
+## Driver Quick Map
 
 ```
-                    [View/Back]  [Menu/Start]
-    
-    [LB]                                        [RB]
-    [LT]                                        [RT]
-    
-         (Left Stick)                  (Right Stick)
-    
-                       [POV/D-Pad]
-                     
-              [X]           [Y]
-                  [Xbox]   
-              [A]           [B]
-```
+LB: Intake jam clear                           RB: (unused)
+LT: Intake run                                 RT: Full close-shot sequence
 
-### Driver (Port 0) Quick Map
+Left Stick: Translate                          Right Stick X: Rotate
 
-```
-LB: Reset Heading                              RB: (unused)
-LT: (unused)                                   RT: (unused)
+                    POV Up: Shooter eject
+        POV Left: Retract climber   POV Right: Extend climber
+                  POV Down: (unused)
 
-Left Stick: Translate                          Right Stick: Rotate
+              X: Far shot      Y: (unused)
 
-                    POV Up: Slow Forward
-        POV Left:                  POV Right:
-                  (unused)           (unused)
-                  POV Down: Slow Backward
-
-              X: (SysId)    Y: (SysId)
-                      
-              A: Brake      B: Point Wheels
-```
-
-### Operator (Port 1) Quick Map
-
-```
-LB: Stop Intake Jam                            RB: Feed to Shooter
-LT: Run Intake                                 RT: Spin Up Shooter
-
-(unused)                                       (unused)
-
-                    POV Up: Eject from Shooter
-        POV Left:                  POV Right:
-        Retract Climber            Extend Climber
-                  POV Down: Eject from Indexer
-
-              X: Far Shot   Y: Close Shot
-                      
-              A: Shoot      B: Idle Shooter
-              Sequence
+              A: Close shot    B: Pass shot
+              Start: Reset heading
 ```
 
 ---
 
 ## Common Operations
 
-### Shooting Sequence (Manual)
+### Shoot (close shot sequence)
 
-1. **Right Trigger (hold)** → Spin up shooter wheels
-2. Wait for shooter to reach target speed (LED indicator or dashboard)
-3. **Y** or **X** → Set shooter angle (close or far)
-4. Wait for angle adjustment complete (dashboard feedback)
-5. **Right Bumper (hold)** → Feed game piece through indexer
-6. **B** → Return shooter to idle when done
+1. Hold **Right Trigger** (>50%).
+2. Sequence runs while held (close-shot RPM/angle plus feed behavior via command sequence).
 
-### Shooting Sequence (Automatic)
+### Set Shooter Presets
 
-1. **A** → Execute full close shot sequence automatically
-   - Spins up shooter
-   - Sets close shot angle and speed
-   - Feeds game piece when ready
-   - Returns to idle
+- **A**: Close shot preset
+- **X**: Far shot preset
+- **B**: Pass shot preset
 
-### Collecting Game Pieces
+### Intake
 
-1. **Left Trigger (hold)** → Run intake
-2. Release when game piece is secured
-3. **Left Bumper** if jam occurs → Quick reverse
+- Hold **Left Trigger** to run intake.
+- Press **Left Bumper** to clear jams.
 
-### Clearing Jams
+### Climber
 
-- **Intake jam:** Left Bumper (quick reverse)
-- **Indexer jam:** POV Down (1 second reverse)
-- **Shooter jam:** POV Up (1 second reverse)
-
-### Climbing Sequence
-
-1. **POV Right (hold)** → Extend climber arm to bar
-2. Release when positioned
-3. **POV Left (hold)** → Retract to lift robot
-4. **Start** → Stop climber when complete
+- Hold **POV Right** to extend.
+- Hold **POV Left** to retract.
 
 ---
 
 ## Troubleshooting
 
 | Issue | Likely Cause | Solution |
-|-------|--------------|----------|
-| Robot drives wrong direction | Field-centric heading not reset | Press **Left Bumper** (driver) |
-| Robot not responding | Wrong controller port | Verify controller is plugged into correct USB port |
-| Intake won't stop | Button held down | Release **Left Trigger** |
-| Shooter spinning but not feeding | Feed not activated | Hold **Right Bumper** to feed |
-| Climber not moving | Climber stopped | Ensure **Start** hasn't been pressed |
-| Drive feels "backward" | Facing wrong direction | Press **Left Bumper** to reset heading |
-
----
-
-## Controller Testing Checklist
-
-Before each match or practice session:
-
-### Driver Controller (Port 0)
-- [ ] Left stick translates robot in all directions
-- [ ] Right stick rotates robot smoothly
-- [ ] **A** button locks wheels in X pattern
-- [ ] **Left Bumper** resets heading
-- [ ] **POV Up/Down** slow drive works
-
-### Operator Controller (Port 1)
-- [ ] **Left Trigger** activates intake
-- [ ] **Right Trigger** spins up shooter
-- [ ] **Y/X** set shooter angles
-- [ ] **Right Bumper** feeds indexer
-- [ ] **A** runs full shoot sequence
-- [ ] **POV Left/Right** move climber
-- [ ] All eject buttons (POV Up/Down, Left Bumper) work
-
----
-
-## Notes for Drivers
-
-- **Field-centric drive:** Robot moves relative to field, not its own orientation
-  - Push left stick forward → robot moves away from driver station
-  - Even if robot is rotated 180°, forward stick still moves away from driver
-- **Reset heading:** Press **Left Bumper** when robot is facing away from driver station
-- **Brake mode:** Use **A** button for quick defensive positioning
-- **Slow drive:** Use POV for precise alignment and docking
-
-## Notes for Operators
-
-- **Trigger thresholds:** Both triggers require > 50% press to activate
-- **Hold vs Press:** Some buttons must be held (triggers, bumpers), others are single press (A/B/X/Y)
-- **Eject functions:** All eject operations run for 1 second automatically
-- **Shoot sequence:** Button **A** is the preferred method for standard shots
-- **POV priority:** POV directions control different subsystems:
-  - Up/Down: Shooter/Indexer eject
-  - Left/Right: Climber movement
+|------|--------------|----------|
+| Robot drives with wrong field orientation | Heading needs reseed | Press **Start** on driver controller |
+| Shooter does not run sequence | Trigger under threshold | Hold **Right Trigger** past 50% |
+| Intake does not run | Trigger under threshold | Hold **Left Trigger** past 50% |
+| Operator inputs do nothing | No bindings on port 1 | Use driver controller bindings |
 
 ---
 
 ## Configuration Location
 
-Controller bindings are configured in `src/main/java/frc/robot/RobotContainer.java`.
-
-See `configureBindings()` method for implementation details.
-
----
-
-**Remember:** Controllers must be connected before robot code starts. Reconnecting during operation may cause unexpected behavior. If controllers are disconnected, disable and re-enable robot code.
+Controller bindings are configured in `src/main/java/frc/robot/RobotContainer.java`, inside `configureBindings()`.


### PR DESCRIPTION
### Motivation

- Ensure the controller reference matches the actual bindings implemented in `RobotContainer.java` so drivers/operators are not misinformed.
- The prior documentation described operator bindings that are not present in code and omitted that the driver controller contains active mechanism controls.
- Make it clear which commented mappings are intentionally disabled to avoid confusion during testing and matches review expectations.

### Description

- Rewrote `src/main/java/frc/robot/docs/controller-reference.md` to reflect the active bindings found in `RobotContainer.configureBindings()` and to point at the correct configuration location.
- Clarified that the driver controller (port 0) handles drivetrain plus active shooter/intake/climber controls and that the operator controller (port 1) currently has no active bindings.
- Documented the live mappings: `Start` reseeds heading, `Right Trigger` (>50%) runs the full close-shot sequence while held, `A`/`X`/`B` set shooter presets, `POV Up` ejects the shooter (1s), `Left Trigger` (>50%) runs intake, `Left Bumper` clears intake jams, and `POV Right`/`POV Left` control climber extend/retract.
- Added a "Currently Unbound / Disabled in Code" section enumerating mappings that exist only as commented code (swerve brake, point wheels, SysId combos, operator-fed shooter/indexer bindings, etc.).

### Testing

- Ran the automated test task with `./gradlew test` and it failed in this environment with `Unsupported class file major version 69` (Java/Gradle class version mismatch), so the test suite could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bf552f5ac832aa34c51413d89772d)