### PR TITLE
Add shooter flywheel RPM increment/decrement testing hooks

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -184,6 +184,11 @@ public class RobotContainer {
         // Left Bumper: Stop intake jam (quick reverse)
         driver.leftBumper().onTrue(intakeCommands.stopJam(intake));
 
+        // ----- Shooter fine-tune (Operator POV) -----
+        // TODO: Uncomment when hardware testing is scheduled.
+        // operator.povUp().onTrue(ShooterCommands.increaseTargetVelocity(shooter, ShooterSubsystem.FLYWHEEL_TEST_INCREMENT_RPM));
+        // operator.povDown().onTrue(ShooterCommands.decreaseTargetVelocity(shooter, ShooterSubsystem.FLYWHEEL_TEST_INCREMENT_RPM));
+
         // ----- Climber (POV) -----
         // POV Up: Extend climber arm (preset})
         //  driver.povUp().onTrue(climber.extendArm());

--- a/src/main/java/frc/robot/commands/ShooterCommands.java
+++ b/src/main/java/frc/robot/commands/ShooterCommands.java
@@ -253,6 +253,30 @@ public class ShooterCommands {
     }
 
     /**
+     * Creates a command to increase target flywheel RPM by the provided increment.
+     *
+     * @param shooter The shooter subsystem
+     * @param incrementRPM RPM delta to apply (positive increases)
+     * @return Command that adjusts target flywheel velocity
+     */
+    public static Command increaseTargetVelocity(ShooterSubsystem shooter, double incrementRPM) {
+        return Commands.runOnce(() -> shooter.adjustTargetVelocity(Math.abs(incrementRPM)), shooter)
+            .withName("IncreaseShooterTargetVelocity");
+    }
+
+    /**
+     * Creates a command to decrease target flywheel RPM by the provided increment.
+     *
+     * @param shooter The shooter subsystem
+     * @param decrementRPM RPM delta to apply (positive value expected)
+     * @return Command that adjusts target flywheel velocity
+     */
+    public static Command decreaseTargetVelocity(ShooterSubsystem shooter, double decrementRPM) {
+        return Commands.runOnce(() -> shooter.adjustTargetVelocity(-Math.abs(decrementRPM)), shooter)
+            .withName("DecreaseShooterTargetVelocity");
+    }
+
+    /**
      * Creates a command to warm up shooter (SPINUP state).
      * Pre-revs flywheel at 20% max for quick response when needed.
      *

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -122,6 +122,9 @@ public class ShooterSubsystem extends SubsystemBase {
     public static final double FAR_SHOT_RPM = 5000.0;  // TODO: Tune
     public static final double FAR_SHOT_ANGLE = 45.0;  // TODO: Tune
 
+    /** Default tuning increment for flywheel speed adjustments during testing. */
+    public static final double FLYWHEEL_TEST_INCREMENT_RPM = 100.0;
+
     /**
      * Creates a new ShooterSubsystem.
      *
@@ -394,6 +397,30 @@ public class ShooterSubsystem extends SubsystemBase {
         if (currentState == ShooterState.READY) {
             io.setFlywheelVelocity(targetFlywheelRPM);
         }
+    }
+
+    /**
+     * Adjusts target flywheel velocity by a delta (positive increases, negative decreases).
+     * Useful for operator fine-tuning during testing.
+     *
+     * @param deltaRPM Amount to add to current target RPM
+     */
+    public void adjustTargetVelocity(double deltaRPM) {
+        setTargetVelocity(targetFlywheelRPM + deltaRPM);
+    }
+
+    /**
+     * Increases target flywheel velocity by the default testing increment.
+     */
+    public void increaseTargetVelocity() {
+        adjustTargetVelocity(FLYWHEEL_TEST_INCREMENT_RPM);
+    }
+
+    /**
+     * Decreases target flywheel velocity by the default testing increment.
+     */
+    public void decreaseTargetVelocity() {
+        adjustTargetVelocity(-FLYWHEEL_TEST_INCREMENT_RPM);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Provide a simple, safe way to incrementally tune the shooter flywheel target RPM during testing without changing main shot presets.
- Allow operator control mapping (POV up/down) for quick adjustments while keeping bindings commented out until hardware testing.

### Description
- Added a default test increment constant `FLYWHEEL_TEST_INCREMENT_RPM = 100.0` to `src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java`.
- Implemented `adjustTargetVelocity(double)`, `increaseTargetVelocity()`, and `decreaseTargetVelocity()` in the `ShooterSubsystem` to change the target RPM incrementally and clamp via existing `setTargetVelocity` logic.
- Added command factories `increaseTargetVelocity(...)` and `decreaseTargetVelocity(...)` to `src/main/java/frc/robot/commands/ShooterCommands.java` to expose these adjustments as one-shot commands for controller bindings.
- Inserted commented operator POV bindings in `src/main/java/frc/robot/RobotContainer.java` (with a `TODO` to uncomment) to map operator POV up/down to the new commands for future hardware testing.

### Testing
- Ran `./gradlew compileJava` to validate compilation, which failed in this environment due to a local Java/Gradle compatibility issue reported as `Unsupported class file major version 69` and not due to the code changes themselves.  No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c00c499b4832aa804dfa92be88ad5)