### PR TITLE
Add Shooter subsystem dashboard and refactor state machine

### DIFF
--- a/elastic-dashboard.json
+++ b/elastic-dashboard.json
@@ -1195,6 +1195,230 @@
         ],
         "containers": []
       }
+    },
+    {
+      "name": "Shooter",
+      "grid_layout": {
+        "layouts": [
+          {
+            "title": "State",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 512.0,
+            "height": 192.0,
+            "type": "List Layout",
+            "properties": {
+              "label_position": "TOP"
+            },
+            "children": [
+              {
+                "title": "Shooter State",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 256.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/State",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Ready",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Boolean Box",
+                "properties": {
+                  "topic": "/Shooter/IsReady",
+                  "period": 0.06,
+                  "data_type": "boolean",
+                  "true_color": 4278255360,
+                  "false_color": 4294901760,
+                  "true_icon": "None",
+                  "false_icon": "None"
+                }
+              }
+            ]
+          },
+          {
+            "title": "Flywheel",
+            "x": 0.0,
+            "y": 192.0,
+            "width": 512.0,
+            "height": 384.0,
+            "type": "List Layout",
+            "properties": {
+              "label_position": "TOP"
+            },
+            "children": [
+              {
+                "title": "Flywheel RPM",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 192.0,
+                "height": 64.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/FlywheelRPM",
+                  "period": 0.06,
+                  "data_type": "double",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Target RPM",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 192.0,
+                "height": 64.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/TargetFlywheelRPM",
+                  "period": 0.06,
+                  "data_type": "double",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Flywheel Error (RPM)",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 192.0,
+                "height": 64.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/FlywheelError",
+                  "period": 0.06,
+                  "data_type": "double",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Applied Volts",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 192.0,
+                "height": 64.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/FlywheelAppliedVolts",
+                  "period": 0.06,
+                  "data_type": "double",
+                  "show_submit_button": false
+                }
+              }
+            ]
+          },
+          {
+            "title": "Hood",
+            "x": 512.0,
+            "y": 0.0,
+            "width": 512.0,
+            "height": 576.0,
+            "type": "List Layout",
+            "properties": {
+              "label_position": "TOP"
+            },
+            "children": [
+              {
+                "title": "Hood Position (rot)",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 192.0,
+                "height": 64.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/HoodAngle",
+                  "period": 0.06,
+                  "data_type": "double",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Target Hood (rot)",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 192.0,
+                "height": 64.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/TargetHoodAngle",
+                  "period": 0.06,
+                  "data_type": "double",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Hood Error (rot)",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 192.0,
+                "height": 64.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/HoodError",
+                  "period": 0.06,
+                  "data_type": "double",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Hood At Pose",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Boolean Box",
+                "properties": {
+                  "topic": "/Shooter/HoodAtPose",
+                  "period": 0.06,
+                  "data_type": "boolean",
+                  "true_color": 4278255360,
+                  "false_color": 4294944000,
+                  "true_icon": "None",
+                  "false_icon": "None"
+                }
+              },
+              {
+                "title": "ThroughBore (rot)",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 192.0,
+                "height": 64.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/ThroughBorePosition",
+                  "period": 0.06,
+                  "data_type": "double",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "ThroughBore Connected",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 64.0,
+                "type": "Boolean Box",
+                "properties": {
+                  "topic": "/Shooter/ThroughBoreConnected",
+                  "period": 0.06,
+                  "data_type": "boolean",
+                  "true_color": 4278255360,
+                  "false_color": 4294901760,
+                  "true_icon": "None",
+                  "false_icon": "None"
+                }
+              }
+            ]
+          }
+        ],
+        "containers": []
+      }
     }
   ]
 }

--- a/src/main/java/frc/robot/commands/ShooterCommands.java
+++ b/src/main/java/frc/robot/commands/ShooterCommands.java
@@ -16,7 +16,7 @@ import frc.robot.subsystems.shooter.ShooterSubsystem;
  * SHOT FLOW:
  * 1. Driver presses preset (A/X/B) — silently arms target RPM and hood angle
  * 2. Driver holds shoot trigger — flywheel ramps to target, hood moves, waits until ready, feeds
- * 3. Driver releases trigger — returns to SPINUP at IDLE_RPM
+ * 3. Driver releases trigger — returns to IDLE (TODO: STANDBY once spin logic validated)
  *
  * Pattern used by: FRC 254, 1678, 6328, and other top teams
  *


### PR DESCRIPTION
## Summary
This PR adds comprehensive dashboard telemetry for the Shooter subsystem and refactors the state machine implementation with improved documentation and safety checks.

## Key Changes

### Dashboard (elastic-dashboard.json)
- Added new "Shooter" tab with three organized sections:
  - **State**: Displays current shooter state and readiness status
  - **Flywheel**: Shows RPM, target RPM, error, and applied voltage
  - **Hood**: Displays hood angle, target angle, error, at-pose status, and through-bore encoder data

### Shooter Subsystem Refactoring (ShooterSubsystem.java)
- **State Machine Documentation**: Clarified state descriptions and shot flow in class-level comments
- **Safety Improvements**:
  - Added `EJECT_MAX_ENTRY_RPM` constant to prevent violent motor reversal
  - Implemented velocity gating in `eject()` method — refuses eject if flywheel exceeds safe threshold
  - Added `isOverCurrent()` method for current monitoring
  
- **NetworkTables Publishers**: 
  - Renamed publishers for clarity (e.g., `FlywheelLeaderMotorRPM` → `FlywheelRPM`)
  - Added new publishers: `FlywheelMotorRPS`, `HoodAngle`, `TargetHoodAngle`
  - Removed unused `FarShotArmed` publisher
  - Enabled previously commented-out error and angle telemetry

- **Code Cleanup**:
  - Removed commented-out far shot armed logic
  - Aligned field declarations with consistent spacing
  - Simplified `returnToStandby()` implementation
  - Added `flywheelRampTest()` command for testing
  - Improved method documentation and comments

- **State Enum**: Updated descriptions to match actual behavior (e.g., PASS now explicitly references `PASS_RPM` and `PASS_HOOD`)

### ShooterCommands.java
- Minor documentation updates to shot flow comments

## Implementation Details
- All dashboard widgets poll at 60Hz (0.06s period) for responsive feedback
- Hood and flywheel errors are now calculated and published in real-time
- Eject command includes safety check: `if (Math.abs(getCurrentVelocityRPM()) > EJECT_MAX_ENTRY_RPM) return;`
- Boolean indicators use color coding: green (true) and red/orange (false) for quick visual feedback

https://claude.ai/code/session_017FU222Bnp9H3FpsZuhAbSC