### PR TITLE
Add vision-based shooter alignment and tuning guide

### DIFF
--- a/TUNING.md
+++ b/TUNING.md
@@ -1,0 +1,196 @@
+# Vision Shooter Tuning Guide
+
+This document covers everything needed to tune the vision-based shooting system end-to-end:
+camera constants → distance verification → shooter lookup table → rotational alignment.
+
+Work through the sections in order. Each section depends on the previous one being correct.
+
+---
+
+## § 1  Pre-Session: One-Time Physical Measurements
+
+Measure these before any on-robot tuning. Get them right once and you will not need to revisit them unless the camera mount changes.
+
+| Measurement | Location in code | How to measure |
+|---|---|---|
+| `CAMERA_HEIGHT_METERS` | `Constants.Vision` | Floor to the center of the Limelight 4 lens, robot on a level surface |
+| `CAMERA_ANGLE_DEGREES` | `Constants.Vision` | Angle of camera from horizontal, positive = tilted up. Use a digital angle gauge or protractor against the camera face |
+| `APRILTAG_HEIGHT_METERS` | `Constants.Vision` | Floor to center of the hub AprilTag face. Look this up in the 2026 game manual field drawings |
+
+Also verify in Limelight web UI that the camera pose is configured to match physical mounting (used by MegaTag2 odometry). These values are separate from the robot code constants but must reflect the same physical reality.
+
+---
+
+## § 2  Hub AprilTag IDs
+
+**Before any testing, verify these against the 2026 game manual and the WPILib field layout JSON.**
+
+The WPILib field layout JSON is included with the WPILib release (usually `2026-crescendo.json` or equivalent) and lists every tag ID with its field position.
+
+| Alliance | Constant | Current placeholder |
+|---|---|---|
+| Blue hub | `BLUE_HUB_MIN/MAX_TAG_ID` | 23 – 28 |
+| Red hub  | `RED_HUB_MIN/MAX_TAG_ID`  | 1 – 6 (NOT verified) |
+
+Wrong IDs → `isHubTarget()` returns false → vision targeting never activates. Verify first.
+
+---
+
+## § 3  Distance Verification
+
+Before filling in the shooter lookup table you need to confirm that `Vision/Distance_m` on the Elastic dashboard matches the real floor distance to the hub.
+
+**Procedure:**
+
+1. Place the robot on a level floor, directly facing a hub AprilTag.
+2. Use a tape measure to record the distance from the bumper (or a consistent reference point on the robot) to the tag face. Write down: `1.0 m`, `2.0 m`, `3.0 m`, `4.0 m`, `5.0 m`, `6.0 m`.
+3. Enable Teleop. Watch `Vision/Distance_m` and `Vision/State` on Elastic.
+4. For each measured distance, compare `Vision/Distance_m` to the tape measure reading.
+
+**If values do not match:**
+
+The distance formula is:
+```
+distance = (APRILTAG_HEIGHT_METERS - CAMERA_HEIGHT_METERS) / tan(CAMERA_ANGLE_DEGREES + ty)
+```
+- Reads too **far**: camera height is understated OR camera angle is overstated.
+- Reads too **close**: camera height is overstated OR camera angle is understated.
+- Adjust `CAMERA_HEIGHT_METERS` and `CAMERA_ANGLE_DEGREES` in `Constants.Vision` and retest.
+
+**Acceptance criterion:** `Vision/Distance_m` within ±0.1 m of tape measure at all tested distances before proceeding.
+
+**Also verify:**
+- `Vision/State` shows `TARGET_ACQUIRED` or `ALIGNED` (not `NO_TARGET`).
+- `Vision/TagID` shows the expected hub tag number.
+- `Vision/IsHubTarget` (add to Elastic if desired, or check via NT Browser) is `true`.
+
+---
+
+## § 4  Shooter Lookup Table Tuning
+
+Fill in `FLYWHEEL_RPM_MAP` and `HOOD_ROT_MAP` in `ShooterSubsystem.java`.
+
+**Setup:**
+- Level floor, robot facing hub tag directly (tx ≈ 0°).
+- Balls/fuel loaded in hopper.
+- Operator controller available to nudge RPM/hood between shots (or use POV cycling for preset reference).
+
+**Procedure (repeat at each distance row):**
+
+1. Place robot at the target distance (confirmed via `Vision/Distance_m`).
+2. Hold RT. Robot enters `VisionAlignAndShoot` — flywheel spins to the current map value.
+3. Watch `Shooter/FlywheelRPM`, `Shooter/TargetFlywheelRPM`, `Shooter/HoodRotations`, `Shooter/TargetHoodRotations` on Elastic.
+4. Wait for `Shooter/IsReady = true`. The indexer will feed automatically.
+5. Observe where the shot lands:
+   - **Short / hits low**: increase RPM and/or decrease hood (lower number = flatter/closer angle).
+   - **Long / hits high**: decrease RPM and/or increase hood.
+   - **Correct but arc is wrong**: adjust hood angle primarily; adjust RPM secondarily to correct carry.
+6. Adjust values in the map and rebuild. Repeat until shots land center target consistently.
+7. Mark the row as `// Tuned` in the source.
+
+**Data table — fill in as you go:**
+
+| Distance (m) | RPM (measured) | Hood rot (measured) | Notes |
+|---|---|---|---|
+| 1.0 | | | |
+| 2.0 | | | |
+| 3.0 | | | |
+| 4.0 | | | |
+| 5.0 | | | |
+| 6.0 | | | |
+
+**Tips:**
+- Tune the endpoints (1.0 m and 6.0 m) first. The interpolation will give you reasonable in-between values to start from.
+- The flywheel RPM map changes slowly with distance; the hood angle map changes more aggressively. Expect the hood to do most of the work.
+- If shots are consistently biased in one direction across all distances, recheck camera angle or tag height — there may be a systematic distance error.
+- Add extra rows at any distance where interpolation produces noticeably poor results. `InterpolatingDoubleTreeMap` handles arbitrary key counts.
+
+---
+
+## § 5  Rotational Alignment (kP) Tuning
+
+Constant: `Constants.Vision.ROTATIONAL_KP` (default: `0.06` rad/s per degree of tx error)
+
+**Objective:** The drivetrain should smoothly center on the hub tag within ~1 second with no oscillation.
+
+**Dashboard values to watch:**
+- `Vision/HorizontalAngle_deg` — tx error in degrees
+- `Vision/IsAligned` — becomes true when within ±2° (see `ALIGNMENT_TOLERANCE_DEGREES`)
+- `Vision/State` — should reach `ALIGNED` before `Shooter/IsReady` for optimal flow
+
+**Procedure:**
+
+1. Place robot ~3 m from hub tag, offset to one side by ~20°.
+2. Hold RT. Observe how the robot rotates to center.
+3. Watch `Vision/HorizontalAngle_deg` converge toward 0.
+
+| Symptom | Adjustment |
+|---|---|
+| Rotates but takes 2–3+ seconds to center | Increase `ROTATIONAL_KP` by 0.01 steps |
+| Oscillates left/right past center | Decrease `ROTATIONAL_KP` by 0.01 steps |
+| Snaps hard to target then overshoots once | Reduce `MAX_ALIGNMENT_ROTATION_RAD_PER_SEC` |
+| Barely moves even with large tx error | Check `Vision/HorizontalAngle_deg` is publishing non-zero values |
+
+**Acceptance criterion:**
+- Robot centers from 20° offset in under 1.5 seconds.
+- No steady-state oscillation.
+- `Vision/IsAligned` holds true once centered.
+
+**Tolerance adjustment:**
+`ALIGNMENT_TOLERANCE_DEGREES` is currently `2.0°`. This is the threshold for `isAligned()` to return true and for feeding to begin. If shots are landing off-center, tighten this (e.g., `1.5°`). If the robot is spending too much time waiting to align before it can fire, loosen it (e.g., `2.5°`). Always re-check shot accuracy after changing it.
+
+---
+
+## § 6  Combined System Test
+
+Once §3–5 are complete:
+
+1. Position robot at random locations and angles relative to hub, 1–5 m away.
+2. Enable Teleop, hold RT.
+3. Verify sequence:
+   - Flywheel spins up immediately (preset baseline).
+   - Robot rotates to center hub tag.
+   - `Vision/State` reaches `ALIGNED`.
+   - `Shooter/IsReady` becomes true.
+   - Indexer fires automatically.
+   - Shot lands on target.
+4. Drive around while holding RT. Verify:
+   - Left stick translation still works freely.
+   - Rotation tracks the tag as robot moves.
+   - `Shooter/TargetFlywheelRPM` and `Shooter/TargetHoodRotations` update continuously as distance changes.
+5. Test LOST_TARGET grace period: block the camera briefly while aligned. Robot should hold last-known targets for 0.5 s (`TARGET_TIMEOUT_SECONDS`) before resetting.
+
+---
+
+## § 7  Elastic Dashboard Recommended Widgets
+
+| NT Key | Widget type | Purpose |
+|---|---|---|
+| `Vision/State` | Text display | Current alignment state machine state |
+| `Vision/Distance_m` | Number bar (0–8) | Real-time distance to hub |
+| `Vision/HorizontalAngle_deg` | Number bar (−30 to 30) | tx error — watch during kP tuning |
+| `Vision/IsAligned` | Boolean indicator | Green when feeding is permitted |
+| `Vision/TagID` | Integer display | Confirm correct hub tag is tracked |
+| `Shooter/FlywheelRPM` | Graph | Actual vs. target convergence |
+| `Shooter/TargetFlywheelRPM` | Number display | Current interpolated target |
+| `Shooter/HoodRotations` | Number display | Actual hood position |
+| `Shooter/TargetHoodRotations` | Number display | Current interpolated target |
+| `Shooter/IsReady` | Boolean indicator | Green when both flywheel and hood are on-target |
+| `Shooter/SelectedPreset` | Text display | Active fallback preset name |
+
+---
+
+## § 8  Quick Reference: Key Constants
+
+| Constant | File | Purpose |
+|---|---|---|
+| `CAMERA_HEIGHT_METERS` | Constants.Vision | ty-based distance formula |
+| `CAMERA_ANGLE_DEGREES` | Constants.Vision | ty-based distance formula |
+| `APRILTAG_HEIGHT_METERS` | Constants.Vision | ty-based distance formula |
+| `BLUE/RED_HUB_MIN/MAX_TAG_ID` | Constants.Vision | Hub tag filter (must match 2026 game manual) |
+| `ALIGNMENT_TOLERANCE_DEGREES` | Constants.Vision | Threshold for isAligned() |
+| `TARGET_TIMEOUT_SECONDS` | Constants.Vision | Grace period on LOST_TARGET |
+| `ROTATIONAL_KP` | Constants.Vision | Rotation tracking aggressiveness |
+| `MAX_ALIGNMENT_ROTATION_RAD_PER_SEC` | Constants.Vision | Rotation rate clamp |
+| `FLYWHEEL_RPM_MAP` | ShooterSubsystem | Distance → RPM lookup |
+| `HOOD_ROT_MAP` | ShooterSubsystem | Distance → hood position lookup |

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -140,9 +140,32 @@ public final class Constants {
     public static final int BLUE_HUB_MIN_TAG_ID = 23;
     public static final int BLUE_HUB_MAX_TAG_ID = 28;
 
+    // Red hub AprilTag IDs
+    // TODO: Verify these against the 2026 game manual / WPILib field layout JSON
+    public static final int RED_HUB_MIN_TAG_ID = 1;
+    public static final int RED_HUB_MAX_TAG_ID = 6;
+
     // State tracking
     /** Time in seconds before considering target "lost" after losing sight */
     public static final double TARGET_TIMEOUT_SECONDS = 0.5;
+
+    // ── Vision-driven drivetrain rotation ─────────────────────────────────────
+    /**
+     * Proportional gain for rotational alignment: (rad/s output) per (degree of tx error).
+     *
+     * Tuning starting point: 0.06
+     *   - Too low  → slow to center, may not reach ALIGNED before timeout
+     *   - Too high → oscillates left/right around the target
+     * See TUNING.md §5 for step-by-step procedure.
+     */
+    public static final double ROTATIONAL_KP = 0.06;
+
+    /**
+     * Maximum rotational rate the vision command will apply to the drivetrain (rad/s).
+     * Prevents violent snap when tx error is large on first acquisition.
+     * Default: 3.0 rad/s (~172°/s). Reduce if the robot swings too aggressively.
+     */
+    public static final double MAX_ALIGNMENT_ROTATION_RAD_PER_SEC = 3.0;
   }
 
   // =========================================================

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -73,8 +73,8 @@ public class Robot extends LoggedRobot {
             double headingDeg = driveState.Pose.getRotation().getDegrees();
             double omegaRps = Units.radiansToRotations(driveState.Speeds.omegaRadiansPerSecond);
 
-            LimelightHelpers.SetRobotOrientation("limelight", headingDeg, 0, 0, 0, 0, 0);
-            var llMeasurement = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2("limelight");
+            LimelightHelpers.SetRobotOrientation(Constants.Vision.LIMELIGHT4_NAME, headingDeg, 0, 0, 0, 0, 0);
+            var llMeasurement = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(Constants.Vision.LIMELIGHT4_NAME);
             if (llMeasurement != null && llMeasurement.tagCount > 0 && Math.abs(omegaRps) < 2.0) {
                 m_robotContainer.drivetrain.addVisionMeasurement(llMeasurement.pose, llMeasurement.timestampSeconds);
             }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -113,15 +113,24 @@ public class RobotContainer {
         // DRIVER CONTROLLER (Port 0) - Shooter
         // =====================================================================
 
-        // Right Trigger: Shoot with the currently selected preset.
+        // Right Trigger: Vision-aligned shot.
         //
-        // Default preset on startup: CLOSE (Close RPM + Close hood).
-        // Cycle presets with POV Left / POV Right before shooting.
+        // While held:
+        //   - Starts spinning at the current POV-selected preset immediately.
+        //   - If a hub AprilTag is visible: continuously updates RPM + hood from
+        //     the distance lookup table and drives rotation to center the tag.
+        //   - If no hub tag is visible: holds current preset, no rotation override.
+        //   - Fires indexer/conveyor as soon as vision is aligned AND shooter is ready.
+        //   - Driver left stick still controls translation freely throughout.
         //
-        // Sequence: arm preset → ramp flywheel + move hood → wait until ready → feed
-        // On release: stop indexer/conveyor → return shooter to standby.
+        // Cycle the fallback preset with POV Left / POV Right before or during hold.
+        // Active preset name is published to Shooter/SelectedPreset on NetworkTables.
         driver.rightTrigger(0.5).whileTrue(
-            FuelCommands.shootWithSelectedPreset(shooter, indexer)
+            FuelCommands.visionAlignAndShoot(
+                shooter, vision, indexer, drivetrain,
+                () -> -driver.getLeftY() * MaxSpeed,
+                () -> -driver.getLeftX() * MaxSpeed
+            )
         );
 
         // POV Right: Cycle to next preset (Close → Tower → Trench → Pass → Far → Close).

--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -1,10 +1,21 @@
 package frc.robot.commands;
 
+import com.ctre.phoenix6.swerve.SwerveModule.DriveRequestType;
+import com.ctre.phoenix6.swerve.SwerveRequest;
+
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.Constants;
+import frc.robot.generated.TunerConstants;
+import frc.robot.subsystems.CommandSwerveDrivetrain;
 import frc.robot.subsystems.vision.VisionSubsystem;
 import frc.robot.subsystems.indexer.IndexerSubsystem;
 import frc.robot.subsystems.shooter.ShooterSubsystem;
+
+import java.util.function.DoubleSupplier;
+
+import static edu.wpi.first.units.Units.MetersPerSecond;
 
 /**
  * Fuel Commands - Factory for shooter-related commands.
@@ -329,6 +340,106 @@ public class FuelCommands {
             // IndexerCommands.feedTimed(indexer, 0.5), // FIXME to use the IndexerSubsystem's feed method instead of a command from IndexerCommands
             // Commands.runOnce(shooter::returnToStandby, shooter)
         ).withName("VisionShootSequence");
+    }
+
+    // =========================================================================
+    // VISION ALIGN AND SHOOT (primary match command)
+    // =========================================================================
+
+    /**
+     * Combined vision-targeting and shooting command. Intended as the primary RT binding.
+     *
+     * Behavior (all while trigger held):
+     *   1. Arms the current POV-selected preset immediately as a fallback baseline.
+     *   2. Continuously looks for the nearest hub AprilTag (alliance-aware).
+     *   3. If a hub tag is visible (or in grace period): updates flywheel RPM and
+     *      hood position from the distance interpolation table every cycle.
+     *   4. Overrides drivetrain rotation with a P-controller on tx (horizontal angle),
+     *      while still allowing the driver to translate freely with the left stick.
+     *   5. Fires the indexer and conveyor as soon as vision reports aligned AND
+     *      shooter reports ready.  Stops feeding if either condition is lost.
+     *   6. On trigger release: stops indexer, conveyor, and shooter.
+     *
+     * Subsystem requirements: shooter, vision, indexer, drivetrain
+     *   → interrupts the default drive command for the duration of the trigger hold.
+     *
+     * Tuning handles:
+     *   - Constants.Vision.ROTATIONAL_KP            (rotation aggressiveness)
+     *   - Constants.Vision.MAX_ALIGNMENT_ROTATION_RAD_PER_SEC  (rotation clamp)
+     *   - ShooterSubsystem FLYWHEEL_RPM_MAP / HOOD_ROT_MAP     (shooter params)
+     *   See TUNING.md for the step-by-step procedure.
+     *
+     * @param shooter     Shooter subsystem
+     * @param vision      Vision subsystem
+     * @param indexer     Indexer subsystem
+     * @param drivetrain  Swerve drivetrain
+     * @param xSupplier   Driver left-Y velocity in m/s (already scaled by MaxSpeed)
+     * @param ySupplier   Driver left-X velocity in m/s (already scaled by MaxSpeed)
+     */
+    public static Command visionAlignAndShoot(
+            ShooterSubsystem shooter,
+            VisionSubsystem vision,
+            IndexerSubsystem indexer,
+            CommandSwerveDrivetrain drivetrain,
+            DoubleSupplier xSupplier,
+            DoubleSupplier ySupplier) {
+
+        final double maxSpeed = 0.5 * TunerConstants.kSpeedAt12Volts.in(MetersPerSecond);
+
+        // Created once; reused every execute cycle.
+        // FieldCentric: driver controls X/Y translation, vision controls rotation.
+        final SwerveRequest.FieldCentric alignRequest = new SwerveRequest.FieldCentric()
+                .withDeadband(maxSpeed * 0.15)
+                .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
+
+        return Commands.run(() -> {
+
+            // ── 1. Shooter: update from vision or hold current targets ─────────
+            if (vision.isUsableForShooting()) {
+                // Live-update RPM + hood from distance table (also pushes to hardware
+                // if already in READY state — see ShooterSubsystem.updateFromDistance)
+                shooter.updateFromDistance(vision.getDistanceToTargetMeters());
+            }
+            // Keep commanding READY every cycle — setState() no-ops if already there
+            if (shooter.getState() != ShooterSubsystem.ShooterState.READY) {
+                shooter.prepareToShoot();
+            }
+
+            // ── 2. Drivetrain: driver translation + vision rotation ────────────
+            // tx returns 0.0 when NO_TARGET, so rotation correction drops to zero
+            // automatically when the camera has nothing to track.
+            double txDeg = vision.getHorizontalAngleDegrees();
+            double rotRate = MathUtil.clamp(
+                    txDeg * Constants.Vision.ROTATIONAL_KP,
+                    -Constants.Vision.MAX_ALIGNMENT_ROTATION_RAD_PER_SEC,
+                     Constants.Vision.MAX_ALIGNMENT_ROTATION_RAD_PER_SEC);
+
+            drivetrain.setControl(
+                    alignRequest
+                            .withVelocityX(xSupplier.getAsDouble())
+                            .withVelocityY(ySupplier.getAsDouble())
+                            .withRotationalRate(rotRate));
+
+            // ── 3. Feed: only when both conditions met ─────────────────────────
+            if (vision.isAligned() && shooter.isReady()) {
+                indexer.indexerForward();
+                indexer.conveyorForward();
+            } else {
+                indexer.indexerStop();
+                indexer.conveyorStop();
+            }
+
+        }, shooter, vision, indexer, drivetrain)
+        .beforeStarting(Commands.runOnce(() -> {
+            shooter.armSelectedPreset(); // Spin up to the POV-selected preset immediately
+            shooter.prepareToShoot();    // Enter READY state — don't wait for alignment
+        }, shooter))
+        .finallyDo(() -> {
+            indexer.indexerStop();
+            indexer.conveyorStop();
+            shooter.setIdle();
+        })
+        .withName("VisionAlignAndShoot");
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -2,6 +2,7 @@ package frc.robot.subsystems.shooter;
 
 // import org.littletonrobotics.junction.Logger;
 
+import edu.wpi.first.math.interpolation.InterpolatingDoubleTreeMap;
 import edu.wpi.first.networktables.BooleanPublisher;
 import edu.wpi.first.networktables.DoublePublisher;
 import edu.wpi.first.networktables.NetworkTable;
@@ -490,20 +491,70 @@ public class ShooterSubsystem extends SubsystemBase {
         return selectedPreset == ShotPreset.FAR;
     }
 
-    // ==== Vision ====
+    // ==== Vision Lookup Tables ====
 
     /**
-     * Updates shooter targets based on distance to target.
-     * Linear interpolation between close and far shots.
-     * Does NOT change state — call prepareToShoot() after.
+     * Distance-to-RPM and distance-to-hood lookup tables.
+     *
+     * Keys   = distance from hub AprilTag in meters (floor distance, not slant).
+     * Values = target flywheel RPM / hood rotations at that distance.
+     *
+     * InterpolatingDoubleTreeMap linearly interpolates between measured points and
+     * clamps to the nearest endpoint outside the measured range.
+     *
+     * HOW TO FILL IN: See TUNING.md §4 for the full measurement procedure.
+     *   1. Place robot at each distance with a tape measure.
+     *   2. Enable, hold RT, watch Vision/Distance_m on Elastic to confirm distance reads correctly.
+     *   3. Manually command a shot (use POV preset cycling as a baseline).
+     *   4. Adjust RPM/hood until shots land center target.
+     *   5. Record values here, rebuild, repeat at next distance.
+     *
+     * Distances below 1.0 m and above 6.0 m are clamped to the nearest endpoint.
+     * Add or remove rows as the shot envelope changes.
+     */
+    private static final InterpolatingDoubleTreeMap FLYWHEEL_RPM_MAP = new InterpolatingDoubleTreeMap();
+    private static final InterpolatingDoubleTreeMap HOOD_ROT_MAP     = new InterpolatingDoubleTreeMap();
+
+    static {
+        // ── Flywheel RPM vs. distance ──────────────────────────────────────────
+        // TODO: Replace each value with a measured result (see TUNING.md §4)
+        FLYWHEEL_RPM_MAP.put(1.0, 2750.0); // TODO: tune
+        FLYWHEEL_RPM_MAP.put(2.0, 2900.0); // TODO: tune
+        FLYWHEEL_RPM_MAP.put(3.0, 3100.0); // TODO: tune
+        FLYWHEEL_RPM_MAP.put(4.0, 3200.0); // TODO: tune
+        FLYWHEEL_RPM_MAP.put(5.0, 3300.0); // TODO: tune
+        FLYWHEEL_RPM_MAP.put(6.0, 3400.0); // TODO: tune  (hw max ~6380 RPM)
+
+        // ── Hood position (rotations) vs. distance ────────────────────────────
+        // TODO: Replace each value with a measured result (see TUNING.md §4)
+        HOOD_ROT_MAP.put(1.0, 0.00); // TODO: tune  (0.0 = fully up / close)
+        HOOD_ROT_MAP.put(2.0, 1.50); // TODO: tune
+        HOOD_ROT_MAP.put(3.0, 3.00); // TODO: tune
+        HOOD_ROT_MAP.put(4.0, 4.30); // TODO: tune
+        HOOD_ROT_MAP.put(5.0, 5.50); // TODO: tune
+        HOOD_ROT_MAP.put(6.0, 6.00); // TODO: tune  (hw max ~9.14 rot)
+    }
+
+    /**
+     * Updates shooter targets from the interpolation maps for the given distance.
+     *
+     * If the shooter is already in READY state the new targets are pushed to
+     * hardware immediately, enabling continuous live tracking while the trigger
+     * is held.  If not yet in READY, the targets are stored and applied when
+     * prepareToShoot() is called.
+     *
+     * @param distanceMeters Measured distance to hub tag in meters (floor distance)
      */
     public void updateFromDistance(double distanceMeters) {
-        double distance = Math.max(1.0, Math.min(5.0, distanceMeters));
-        double t = (distance - 1.0) / (5.0 - 1.0);
-        double velocity = CLOSE_RPM + t * (FAR_RPM - CLOSE_RPM);
-        double pose = CLOSE_HOOD + t * (FAR_HOOD - CLOSE_HOOD);
-        setTargetVelocity(velocity);
-        setTargetHoodPose(pose);
+        double dist = Math.max(1.0, Math.min(6.0, distanceMeters));
+        setTargetVelocity(FLYWHEEL_RPM_MAP.get(dist));
+        setTargetHoodPose(HOOD_ROT_MAP.get(dist));
+
+        // Push to hardware immediately if already spinning — keeps tracking live
+        if (currentState == ShooterState.READY) {
+            commandFlywheelVelocity(targetFlywheelMotorRPM);
+            io.setHoodPose(targetHoodPoseRot);
+        }
     }
 
     // ==== LEGACY / CONVENIENCE SHIMS ====

--- a/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems.vision;
 
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.networktables.BooleanPublisher;
 import edu.wpi.first.networktables.DoublePublisher;
 import edu.wpi.first.networktables.IntegerPublisher;
@@ -254,6 +255,47 @@ public class VisionSubsystem extends SubsystemBase {
      */
     public int getTagId() {
         return inputs.tagId;
+    }
+
+    /**
+     * Returns true if the currently visible tag is a hub target for the active alliance.
+     *
+     * Defaults to blue alliance if DriverStation has not yet reported alliance color
+     * (e.g., during pre-match or practice mode without FMS).
+     *
+     * NOTE: Hub tag ID ranges must be verified against the 2026 game manual.
+     * Blue: Constants.Vision.BLUE_HUB_MIN/MAX_TAG_ID
+     * Red:  Constants.Vision.RED_HUB_MIN/MAX_TAG_ID
+     */
+    public boolean isHubTarget() {
+        int id = inputs.tagId;
+        if (id < 0) return false;
+
+        var alliance = DriverStation.getAlliance();
+        if (alliance.isPresent() && alliance.get() == DriverStation.Alliance.Red) {
+            return id >= Constants.Vision.RED_HUB_MIN_TAG_ID
+                && id <= Constants.Vision.RED_HUB_MAX_TAG_ID;
+        }
+        // Default / blue alliance
+        return id >= Constants.Vision.BLUE_HUB_MIN_TAG_ID
+            && id <= Constants.Vision.BLUE_HUB_MAX_TAG_ID;
+    }
+
+    /**
+     * Returns true when vision data is safe to use for shooter parameter updates.
+     *
+     * True when:
+     *   - An active hub target is locked (TARGET_ACQUIRED or ALIGNED), OR
+     *   - We just lost a hub target and are in the grace period (LOST_TARGET with valid last-known distance)
+     *
+     * False when no target has ever been seen or the grace period has expired.
+     */
+    public boolean isUsableForShooting() {
+        if (currentState == AlignmentState.LOST_TARGET) {
+            // Grace period: use last-known distance rather than resetting the shooter
+            return lastKnownDistance > 0.1;
+        }
+        return hasTarget() && isHubTarget() && getDistanceToTargetMeters() > 0.1;
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
Implements a complete vision-based shooting system that allows the robot to automatically align to hub AprilTags and adjust shooter parameters (RPM and hood angle) based on distance. Includes a comprehensive tuning guide documenting the end-to-end calibration procedure.

## Key Changes

**New Documentation:**
- Added `TUNING.md` with step-by-step procedures for:
  - Physical camera measurements (height, angle)
  - Hub AprilTag ID verification
  - Distance verification against tape measure
  - Shooter lookup table tuning at multiple distances
  - Rotational alignment (kP) tuning
  - Combined system testing
  - Elastic dashboard widget recommendations

**Vision System Enhancements:**
- Added `isHubTarget()` method to verify currently tracked tag is a hub target for the active alliance (blue/red aware)
- Added `isUsableForShooting()` method to determine if vision data is safe for shooter updates, including grace period handling when target is briefly lost
- Added red hub AprilTag ID constants (`RED_HUB_MIN/MAX_TAG_ID`) to match blue hub constants

**Shooter Lookup Tables:**
- Replaced linear interpolation between close/far presets with distance-based lookup tables using `InterpolatingDoubleTreeMap`
- Added `FLYWHEEL_RPM_MAP` and `HOOD_ROT_MAP` with placeholder values at 1.0–6.0 m distances
- Updated `updateFromDistance()` to query the maps and push updates to hardware immediately when already in READY state, enabling live tracking

**Vision-Aligned Shooting Command:**
- Implemented `visionAlignAndShoot()` command as the primary RT (right trigger) binding
- Behavior while held:
  - Arms the POV-selected preset immediately as fallback
  - Continuously updates flywheel RPM and hood from distance interpolation
  - Overrides drivetrain rotation with P-controller on tx (horizontal angle error)
  - Allows driver to translate freely with left stick
  - Fires indexer/conveyor only when vision is aligned AND shooter is ready
  - Stops all systems on trigger release
- Uses `SwerveRequest.FieldCentric` for combined driver translation + vision rotation control

**Constants and Tuning Parameters:**
- Added `ROTATIONAL_KP` (default 0.06 rad/s per degree) for vision-based rotation tracking
- Added `MAX_ALIGNMENT_ROTATION_RAD_PER_SEC` (default 3.0) to clamp rotation rate and prevent aggressive snapping
- Added red hub tag ID range constants with TODO note to verify against 2026 game manual

**RobotContainer Integration:**
- Updated right trigger binding from `shootWithSelectedPreset()` to `visionAlignAndShoot()`
- Passes driver left stick suppliers for translation velocity to the new command

## Notable Implementation Details

- Distance lookup uses `InterpolatingDoubleTreeMap` which linearly interpolates between measured points and clamps outside the range, allowing arbitrary key counts and easy addition of intermediate distances
- Vision rotation correction automatically drops to zero when no target is visible (tx returns 0.0 in NO_TARGET state)
- Shooter targets are pushed to hardware immediately when already in READY state, enabling continuous live tracking during trigger hold
- Grace period (`TARGET_TIMEOUT_SECONDS`) allows shooter to maintain last-known distance briefly after losing sight of tag, preventing jarring resets
- All tuning parameters are documented with starting values and adjustment guidance in both code comments and TUNING.md

https://claude.ai/code/session_01B4325hWwLRRddXsCjUHtUz