### PR TITLE
Move shooter preset selection d-pad to face buttons + right bumper

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -117,32 +117,23 @@ public class RobotContainer {
         driver.rightTrigger(0.5).whileTrue(
             FuelCommands.shootWithSelectedPreset(shooter, indexer)
         );
-        // Right Trigger: Vision-aligned shot.
-        //
-        // While held:
-        //   - Starts spinning at the current POV-selected preset immediately.
-        //   - If a hub AprilTag is visible: continuously updates RPM + hood from
-        //     the distance lookup table and drives rotation to center the tag.
-        //   - If no hub tag is visible: holds current preset, no rotation override.
-        //   - Fires indexer/conveyor as soon as vision is aligned AND shooter is ready.
-        //   - Driver left stick still controls translation freely throughout.
-        //
-        // Cycle the fallback preset with POV Left / POV Right before or during hold.
-        // Active preset name is published to Shooter/SelectedPreset on NetworkTables.
-        driver.rightTrigger(0.5).and(driver.a()).whileTrue(
-            FuelCommands.visionAlignAndShoot(
-                shooter, vision, indexer, drivetrain,
-                () -> -driver.getLeftY() * MaxSpeed,
-                () -> -driver.getLeftX() * MaxSpeed
-            )
-        );
+        // Right Trigger + Vision: Commented out — vision shot disabled for now.
+        // driver.rightTrigger(0.5).and(driver.a()).whileTrue(
+        //     FuelCommands.visionAlignAndShoot(
+        //         shooter, vision, indexer, drivetrain,
+        //         () -> -driver.getLeftY() * MaxSpeed,
+        //         () -> -driver.getLeftX() * MaxSpeed
+        //     )
+        // );
 
-        // POV Right: Cycle to next preset (Close → Tower → Trench → Pass → Far → Close).
-        // POV Left:  Cycle to previous preset (Close → Far → Pass → Trench → Tower → Close).
-        // Selected preset is published to Shooter/SelectedPreset on NetworkTables / Elastic.
-        // No subsystem requirement — safe to press while trigger is held without interrupting a shot.
-        driver.povRight().onTrue(Commands.runOnce(shooter::cyclePresetForward));
-        driver.povLeft().onTrue(Commands.runOnce(shooter::cyclePresetBackward));
+        // Face buttons select and latch preset (selection sticks after button released).
+        // A = CLOSE, B = TRENCH, X = TOWER, Y = FAR
+        // Right Bumper = PASS
+        driver.a().onTrue(Commands.runOnce(() -> shooter.selectPreset(ShooterSubsystem.ShotPreset.CLOSE)));
+        driver.b().onTrue(Commands.runOnce(() -> shooter.selectPreset(ShooterSubsystem.ShotPreset.TRENCH)));
+        driver.x().onTrue(Commands.runOnce(() -> shooter.selectPreset(ShooterSubsystem.ShotPreset.TOWER)));
+        driver.y().onTrue(Commands.runOnce(() -> shooter.selectPreset(ShooterSubsystem.ShotPreset.FAR)));
+        driver.rightBumper().onTrue(Commands.runOnce(() -> shooter.selectPreset(ShooterSubsystem.ShotPreset.PASS)));
 
         // =====================================================================
         // DRIVER CONTROLLER (Port 0) - Intake

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -467,6 +467,15 @@ public class ShooterSubsystem extends SubsystemBase {
     }
 
     /**
+     * Directly selects a specific preset and arms it silently.
+     * The selection sticks until another preset is chosen.
+     */
+    public void selectPreset(ShotPreset preset) {
+        selectedPreset = preset;
+        armSelectedPreset();
+    }
+
+    /**
      * Advances to the next preset in the cycle order:
      * Close → Tower → Trench → Pass → Far → Close
      * Arms the new preset silently so it's ready when RT is pressed.


### PR DESCRIPTION
- Replace POV cycling with direct preset selection via face buttons: A=CLOSE, B=TRENCH, X=TOWER, Y=FAR, RightBumper=PASS
- Add selectPreset(ShotPreset) to ShooterSubsystem so selection latches on press and sticks after button is released
- Comment out vision align-and-shoot binding for now