### PR TITLE
fix(shooter): address state machine audit findings

### DIFF
--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -43,7 +43,7 @@ public class FuelCommands {
     public static Command shootAtCurrentTarget(ShooterSubsystem shooter, IndexerSubsystem indexer) {
         return Commands.sequence(
                 Commands.runOnce(shooter::prepareToShoot, shooter),
-                Commands.waitUntil(shooter::isReady).withTimeout(1.0),
+                Commands.waitUntil(shooter::isReady).withTimeout(3.0),
                 Commands.run(() -> {
                     indexer.indexerForward();
                     indexer.conveyorForward();
@@ -269,8 +269,7 @@ public class FuelCommands {
                 .withName("WaitForShooterReady");
     }
 
-    public static Command shootPass(
-            ShooterSubsystem shooter, IndexerSubsystem indexer, double rpm, double hood) {
+    public static Command shootPass(ShooterSubsystem shooter, IndexerSubsystem indexer) {
         return Commands.sequence(
                 Commands.runOnce(() -> {
                     shooter.setTargetVelocity(Constants.Shooter.PASS_RPM);
@@ -436,7 +435,7 @@ public class FuelCommands {
                     shooter.updateFromDistance(distance);
                     shooter.prepareToShoot();
                 }, shooter, vision),
-                Commands.waitUntil(shooter::isReady)).withTimeout(3.0)
+                Commands.waitUntil(shooter::isReady).withTimeout(3.0))
                 .withName("VisionShot");
     }
 

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -190,12 +190,22 @@ public class ShooterSubsystem extends SubsystemBase {
             case STANDBY:
                 break;
             case READY:
+                // Re-issue every cycle so any silent target change (setTargetVelocity, updateFromDistance)
+                // takes effect immediately, and so the TalonFX recovers automatically if it
+                // drops its setpoint due to a transient fault or CAN dropout.
+                commandFlywheelVelocity(targetFlywheelMotorRPM);
+                io.setHoodPose(targetHoodPoseRot);
                 break;
             case PASS:
+                commandFlywheelVelocity(Constants.Shooter.PASS_RPM);
+                io.setHoodPose(Constants.Shooter.PASS_HOOD);
                 break;
             case EJECT:
+                commandFlywheelVelocity(Constants.Shooter.EJECT_RPM);
                 break;
             case POPPER:
+                commandFlywheelVelocity(Constants.Shooter.POPPER_RPM);
+                io.setHoodPose(Constants.Shooter.POPPER_HOOD);
                 break;
         }
     }
@@ -246,14 +256,14 @@ public class ShooterSubsystem extends SubsystemBase {
     // PUBLIC COMMAND METHODS
     // =========================================================================
 
-    /** Full stop. Not used during normal match play — call returnToStandby() after a shot instead. */
+    /** Full stop — stops flywheels and returns hood to home. */
     public void setIdle() {
         setState(ShooterState.IDLE);
     }
 
     /**
-     * Called after a shot is complete to reset the shooter.
-     * TODO: Do not use right now **EXPERIMENTAL**
+     * Resets shooter after a shot. Currently routes to IDLE because STANDBY
+     * (pre-rev) is not yet active. Update this when STANDBY spin logic is validated.
      */
     public void returnToStandby() {
         setState(ShooterState.IDLE);


### PR DESCRIPTION
ShooterSubsystem:
- updateStateMachine() now re-issues velocity and hood commands every cycle for READY/PASS/EJECT/POPPER states, providing automatic recovery if the TalonFX drops its setpoint due to a transient fault or CAN dropout, and ensuring silent target changes (setTargetVelocity, updateFromDistance) take effect immediately without requiring a state transition
- Fix returnToStandby() Javadoc — previously claimed EXPERIMENTAL/unused; clarified it intentionally routes to IDLE until STANDBY spin logic lands

FuelCommands:
- shootAtCurrentTarget: fix waitUntil timeout 1.0s → 3.0s to match every other shoot command (was an inconsistency from the original template)
- shootPass: remove dead rpm/hood parameters that were accepted but always ignored in favor of Constants.Shooter.PASS_RPM / PASS_HOOD
- visionShot: fix misplaced closing paren — withTimeout(3.0) was applying to the entire sequence() instead of only the waitUntil step

https://claude.ai/code/session_01J6sf5uWPzfyoRpRUTmUpb6