### PR TITLE
fix: cap sensor-clearing step with 2s timeout in all Auto shoot commands

### DIFF
--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -473,7 +473,7 @@ public class FuelCommands {
                     indexer.indexerForward();
                     indexer.conveyorForward();
                 }, indexer).withTimeout(feedSeconds), // primary end trigger: timeout
-                indexer.feed().until(indexer::donePassingFuel)
+                indexer.feed().until(indexer::donePassingFuel).withTimeout(2.0)
         ).finallyDo(() -> {
             indexer.indexerStop();
             indexer.conveyorStop();
@@ -494,7 +494,7 @@ public class FuelCommands {
                         indexer.conveyorForward();
                     }, indexer).withTimeout(feedSeconds), // primary end trigger: timeout
                     // Feed until chute goes quiet for 2s (with safety timeout)
-                    indexer.feed().until(indexer::donePassingFuel)
+                    indexer.feed().until(indexer::donePassingFuel).withTimeout(2.0)
                     // This is likely redundant with the feed().until() end condition, but it's a
                     // good safety net in case of sensor issues or unexpected game piece behavior.
             ).finallyDo(() -> {
@@ -517,7 +517,7 @@ public class FuelCommands {
                     indexer.indexerForward();
                     indexer.conveyorForward();
                 }, indexer).withTimeout(feedSeconds), // primary end trigger: timeout
-                indexer.feed().until(indexer::donePassingFuel)
+                indexer.feed().until(indexer::donePassingFuel).withTimeout(2.0)
         ).finallyDo(() -> {
             indexer.indexerStop();
             indexer.conveyorStop();
@@ -538,7 +538,7 @@ public class FuelCommands {
                     indexer.indexerForward();
                     indexer.conveyorForward();
                 }, indexer).withTimeout(feedSeconds), // primary end trigger: timeout
-                indexer.feed().until(indexer::donePassingFuel)
+                indexer.feed().until(indexer::donePassingFuel).withTimeout(2.0)
         ).finallyDo(() -> {
             indexer.indexerStop();
             indexer.conveyorStop();
@@ -559,7 +559,7 @@ public class FuelCommands {
                         indexer.conveyorForward();
                     }, indexer).withTimeout(feedSeconds), // primary end trigger: timeout
                     // Feed until chute goes quiet for 2s (with safety timeout)
-                    indexer.feed().until(indexer::donePassingFuel)
+                    indexer.feed().until(indexer::donePassingFuel).withTimeout(2.0)
                     // This is likely redundant with the feed().until() end condition, but it's a
                     // good safety net in case of sensor issues or unexpected game piece behavior.
             ).finallyDo(() -> {


### PR DESCRIPTION
donePassingFuel sensor is unreliable, causing the clearing step to hang indefinitely. Added .withTimeout(2.0) to all five
indexer.feed().until(donePassingFuel) calls in FuelCommands.Auto so the command always completes within feedSeconds + 2s regardless of sensor state.

https://claude.ai/code/session_01FNkCnLccgoijLVyXFxbxLp