### PR TITLE
Add flywheel temperature telemetry and RPM-ready indicator

### DIFF
--- a/elastic-dashboard.json
+++ b/elastic-dashboard.json
@@ -1335,6 +1335,37 @@
                   "data_type": "double",
                   "show_submit_button": false
                 }
+              },
+              {
+                "title": "Flywheel Temp (°C)",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 192.0,
+                "height": 64.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/FlywheelMaxTempCelsius",
+                  "period": 0.06,
+                  "data_type": "double",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Flywheel At RPM",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Boolean Box",
+                "properties": {
+                  "topic": "/Shooter/FlywheelAtRPM",
+                  "period": 0.06,
+                  "data_type": "boolean",
+                  "true_color": 4278255360,
+                  "false_color": 4294944000,
+                  "true_icon": "None",
+                  "false_icon": "None"
+                }
               }
             ]
           },

--- a/elastic-layout.json
+++ b/elastic-layout.json
@@ -1335,6 +1335,37 @@
                   "data_type": "double",
                   "show_submit_button": false
                 }
+              },
+              {
+                "title": "Flywheel Temp (°C)",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 192.0,
+                "height": 64.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Shooter/FlywheelMaxTempCelsius",
+                  "period": 0.06,
+                  "data_type": "double",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Flywheel At RPM",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Boolean Box",
+                "properties": {
+                  "topic": "/Shooter/FlywheelAtRPM",
+                  "period": 0.06,
+                  "data_type": "boolean",
+                  "true_color": 4278255360,
+                  "false_color": 4294944000,
+                  "true_icon": "None",
+                  "false_icon": "None"
+                }
               }
             ]
           },

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIO.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIO.java
@@ -53,6 +53,9 @@ public interface ShooterIO {
         /** Flywheel supply current in amps */
         public double flywheelCurrentAmps = 0.0;
 
+        /** Max flywheel motor temperature in Celsius across motors A/B/C */
+        public double flywheelMaxTempCelsius = 0.0;
+
         /** Hood applied voltage */
         public double hoodAppliedVolts = 0.0;
 

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOHardware.java
@@ -146,6 +146,9 @@ public class ShooterIOHardware implements ShooterIO {
   // === Status Signals =====
   private final StatusSignal<?> flywheelAVelocity;
   private final StatusSignal<?> flywheelAMotorVoltage; // applied volts — also re-enabled at 100Hz for follower sync
+  private final StatusSignal<?> flywheelATempCelsius;
+  private final StatusSignal<?> flywheelBTempCelsius;
+  private final StatusSignal<?> flywheelCTempCelsius;
   private final StatusSignal<?> hoodPosition;
   private final StatusSignal<?> hoodEncoderAbsPosition;
 
@@ -172,6 +175,9 @@ public class ShooterIOHardware implements ShooterIO {
     // Cache status signal references
     flywheelAVelocity      = flywheelMotorA.getVelocity();
     flywheelAMotorVoltage  = flywheelMotorA.getMotorVoltage();
+    flywheelATempCelsius   = flywheelMotorA.getDeviceTemp();
+    flywheelBTempCelsius   = flywheelMotorB.getDeviceTemp();
+    flywheelCTempCelsius   = flywheelMotorC.getDeviceTemp();
     hoodPosition           = hoodMotor.getPosition();
     hoodEncoderAbsPosition = hoodEncoder.getAbsolutePosition();
 
@@ -205,6 +211,9 @@ public class ShooterIOHardware implements ShooterIO {
     // Must be set AFTER optimizeBusUtilization() or it will be cleared.
     BaseStatusSignal.setUpdateFrequencyForAll(
         10.0,
+        flywheelATempCelsius,
+        flywheelBTempCelsius,
+        flywheelCTempCelsius,
         hoodEncoderAbsPosition
     );
 
@@ -216,6 +225,15 @@ public class ShooterIOHardware implements ShooterIO {
 
     // Initialize hood to known zero position
     hoodMotor.setPosition(0.0);
+  }
+
+  @Override
+  public void updateSlowInputs(ShooterIOInputs inputs) {
+    BaseStatusSignal.refreshAll(flywheelATempCelsius, flywheelBTempCelsius, flywheelCTempCelsius);
+
+    inputs.flywheelMaxTempCelsius = Math.max(
+        flywheelATempCelsius.getValueAsDouble(),
+        Math.max(flywheelBTempCelsius.getValueAsDouble(), flywheelCTempCelsius.getValueAsDouble()));
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -86,6 +86,8 @@ public class ShooterSubsystem extends SubsystemBase {
     private final DoublePublisher  hoodErrorPublisher;
     private final BooleanPublisher hoodAtPosePublisher;
     private final DoublePublisher  flywheelVoltsPublisher;
+    private final DoublePublisher  flywheelTempPublisher;
+    private final BooleanPublisher flywheelAtRpmPublisher;
     private final DoublePublisher  throughBorePositionPublisher;
     private final BooleanPublisher throughBoreConnectedPublisher;
     private final StringPublisher  selectedPresetPublisher;
@@ -118,6 +120,8 @@ public class ShooterSubsystem extends SubsystemBase {
         hoodErrorPublisher           = shooterTable.getDoubleTopic("HoodError").publish();
         hoodAtPosePublisher          = shooterTable.getBooleanTopic("HoodAtPose").publish();
         flywheelVoltsPublisher       = shooterTable.getDoubleTopic("FlywheelAppliedVolts").publish();
+        flywheelTempPublisher        = shooterTable.getDoubleTopic("FlywheelMaxTempCelsius").publish();
+        flywheelAtRpmPublisher       = shooterTable.getBooleanTopic("FlywheelAtRPM").publish();
         throughBorePositionPublisher  = shooterTable.getDoubleTopic("ThroughBorePosition").publish();
         throughBoreConnectedPublisher = shooterTable.getBooleanTopic("ThroughBoreConnected").publish();
         selectedPresetPublisher       = shooterTable.getStringTopic("SelectedPreset").publish();
@@ -157,6 +161,8 @@ public class ShooterSubsystem extends SubsystemBase {
         hoodErrorPublisher.set(targetHoodPoseRot - inputs.hoodPositionRotations);
         hoodAtPosePublisher.set(isHoodAtPose());
         flywheelVoltsPublisher.set(inputs.flywheelAppliedVolts);
+        flywheelTempPublisher.set(inputs.flywheelMaxTempCelsius);
+        flywheelAtRpmPublisher.set(isFlywheelAtVelocity());
         throughBorePositionPublisher.set(inputs.hoodThroughBorePositionRotations);
         throughBoreConnectedPublisher.set(inputs.hoodThroughBoreConnected);
         selectedPresetPublisher.set(selectedPreset.label);


### PR DESCRIPTION
### Motivation
- Provide a flywheel temperature readout on NetworkTables/dashboard for monitoring motor temps across the three flywheel motors. 
- Add a driver-facing RPM-ready colored indicator (like the hood indicator) so operators can quickly see when the flywheel is at target.

### Description
- Added `flywheelMaxTempCelsius` to `ShooterIO.ShooterIOInputs` to carry the maximum flywheel motor temperature. (`src/main/java/frc/robot/subsystems/shooter/ShooterIO.java`)
- Read device temperatures from flywheel motors A/B/C in `ShooterIOHardware`, scheduled them at 10 Hz, and implemented `updateSlowInputs` to compute and populate `flywheelMaxTempCelsius`. (`src/main/java/frc/robot/subsystems/shooter/ShooterIOHardware.java`)
- Added two NetworkTables publishers in `ShooterSubsystem`: `FlywheelMaxTempCelsius` (double) and `FlywheelAtRPM` (boolean), and publish those values in `publishToElastic()`. (`src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java`)
- Updated dashboard/layout configuration to include a text readout for `/Shooter/FlywheelMaxTempCelsius` and a boolean color indicator `/Shooter/FlywheelAtRPM` (mirrors hood-style coloring). (`elastic-dashboard.json`, `elastic-layout.json`)

### Testing
- Attempted to run `./gradlew compileJava` but the build could not execute in this environment due to a Gradle/JDK incompatibility (`Unsupported class file major version 69`).
- Validated the updated dashboard JSON files parse as valid JSON using Python `json.load(...)` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e2a18e78832ab42a51401c09e61a)