### PR TITLE
Add finallyDo callback to stop roller in intakeFuelAuton

### DIFF
--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -233,6 +233,7 @@ public class IntakeSubsystem extends SubsystemBase {
                 extendSlidesCmd(),
                 Commands.run(this::runRoller, this)
                         .withTimeout(intakeTimeout) // primary end trigger: timeout
+                        .finallyDo(this::stopRoller)
         ).withName("IntakeFuelAuton");
     }
 


### PR DESCRIPTION
## Summary
Added a `finallyDo` callback to the `intakeFuelAuton` command to ensure the roller is properly stopped when the command completes, regardless of how it ends (timeout, cancellation, or error).

## Changes
- Added `.finallyDo(this::stopRoller)` to the roller run command in `intakeFuelAuton()`
- This ensures the `stopRoller()` method is called when the intake timeout completes or the command is interrupted

## Implementation Details
The `finallyDo` callback is chained to the `withTimeout()` call, guaranteeing cleanup of the roller state. This prevents the roller from continuing to run if the command is cancelled or interrupted before the timeout expires.

https://claude.ai/code/session_015J4YTLGQ8nbyi58DZZd4RB