### PR TITLE
Add slide retraction during shooting commands

### DIFF
--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -92,6 +92,32 @@ public class FuelCommands {
                 }).withName("ShootWithPreset[" + rpm + "rpm]");
     }
 
+    /**
+     * Shoots at the given RPM/hood preset while simultaneously retracting the
+     * intake slides (two-phase) and running the intake roller.
+     *
+     * The shooter+indexer sequence is the deadline — slide retraction runs in
+     * parallel and is cancelled when the shot completes or the trigger is released.
+     * The intake roller is always stopped on exit via the intake command's finallyDo.
+     *
+     * Use wherever {@link #shootWithPreset} is used when slides need to retract
+     * during the shot (e.g. after intaking from the trench).
+     *
+     * @param shooter The shooter subsystem
+     * @param indexer The indexer subsystem
+     * @param intake  The intake subsystem
+     * @param rpm     Target flywheel velocity in RPM
+     * @param hood    Target hood position in rotations
+     * @return Deadline command: shoot sequence (deadline) + slide retract in parallel
+     */
+    public static Command shootWithSlideRetract(ShooterSubsystem shooter, IndexerSubsystem indexer,
+            IntakeSubsystem intake, double rpm, double hood) {
+        return Commands.deadline(
+                shootWithPreset(shooter, indexer, rpm, hood),
+                intake.retractSlidesWithRollerCmd())
+                .withName("ShootWithSlideRetract[" + rpm + "rpm]");
+    }
+
     // Template for the using ShotPresets in Auton
     public static Command shootPresetAuton(ShooterSubsystem shooter, IndexerSubsystem indexer,
             ShotPreset preset, double feedSeconds,
@@ -475,6 +501,28 @@ public class FuelCommands {
                 indexer.conveyorStop();
                 shooter.setIdle();
             }).withName("ShootTrenchAuton");
+        }
+
+        /**
+         * Autonomous: shoot at trench preset while retracting intake slides (two-phase)
+         * and running the intake roller concurrently.
+         *
+         * The shoot sequence ({@link #shootTrench}) is the deadline — slide retraction
+         * is cancelled when feeding completes. Safe to compose with path-following or
+         * other parallel commands in auton.
+         *
+         * @param shooter     The shooter subsystem
+         * @param indexer     The indexer subsystem
+         * @param intake      The intake subsystem
+         * @param feedSeconds How long to run the indexer/conveyor after ready
+         * @return Deadline command: shootTrench (deadline) + slide retract in parallel
+         */
+        public static Command shootTrenchWithSlideRetract(ShooterSubsystem shooter,
+                IndexerSubsystem indexer, IntakeSubsystem intake, double feedSeconds) {
+            return Commands.deadline(
+                    shootTrench(shooter, indexer, feedSeconds),
+                    intake.retractSlidesWithRollerCmd())
+                    .withName("ShootTrenchWithSlideRetract");
         }
 
         /* Autonomous shooting command */

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -317,10 +317,47 @@ public class IntakeSubsystem extends SubsystemBase {
     }
 
 
-    /*
-    * Retract slides to a set positional at first (see retractSlidesIncrementalCmd) while running the indexer roller
-    * Retract slides the remaining distance at the slow speed using DynamicMotionMagic until fully retracted, while continuing to run the roller
-    * This should also be used with FuelCommands and shooting the flywheel
-    */
+    /**
+     * Two-phase slide retraction while running the roller.
+     *
+     * Phase 1 (runOnce): Retracts 15 rotations from the current position via
+     * MotionMagic — the same jump as one manual tap of retractSlidesIncrementalCmd.
+     * The roller starts here and stays on.
+     *
+     * Phase 2 (continuous): Uses DynamicMotionMagic to slowly finish retracting
+     * to {@code SLIDE_RETRACTED_POSITION} (0.0), re-commanded every cycle, until
+     * {@link #isSlideFullyRetracted()} is true.
+     *
+     * The roller is stopped in {@code finallyDo} so any deadline interruption
+     * (e.g. shooter sequence finishing) still cleans up properly.
+     *
+     * Intended use: run inside a {@code Commands.deadline()} where the
+     * shooter+indexer sequence is the deadline. The slide retracts and roller
+     * keeps spinning in parallel until the shot completes.
+     *
+     * <pre>
+     *   Commands.deadline(
+     *       FuelCommands.shootWithPreset(shooter, indexer, rpm, hood),
+     *       intake.retractSlidesWithRollerCmd()
+     *   );
+     * </pre>
+     *
+     * Also works in auton alongside {@code FuelCommands.Auto.shootTrench()}.
+     */
+    public Command retractSlidesWithRollerCmd() {
+        return Commands.sequence(
+                // Phase 1: fast initial jump back 15 rotations (same as one manual tap)
+                Commands.runOnce(() -> {
+                    retractSlidesIncremental();
+                    runRoller();
+                }, this),
+                // Phase 2: DynamicMotionMagic slowly to 0.0, re-commanded every cycle
+                Commands.run(() -> {
+                    retractSlidesSlow();
+                    runRoller();
+                }, this).until(this::isSlideFullyRetracted))
+                .finallyDo(() -> stopRoller())
+                .withName("RetractSlidesWithRoller");
+    }
 
 } // end of class


### PR DESCRIPTION
## Summary
This PR adds support for retracting intake slides while simultaneously shooting, enabling smoother transitions after trench intakes. Two new command variants are introduced that run slide retraction in parallel with the shooting sequence.

## Key Changes

- **FuelCommands.shootWithSlideRetract()**: New teleop command that shoots at a given RPM/hood preset while retracting intake slides and running the intake roller in parallel. The shooter+indexer sequence acts as the deadline, cancelling slide retraction when the shot completes.

- **FuelCommands.Auto.shootTrenchWithSlideRetract()**: New autonomous variant that combines trench shooting with concurrent slide retraction and roller operation. Safe to compose with path-following commands.

- **IntakeSubsystem.retractSlidesWithRollerCmd()**: New two-phase slide retraction command:
  - **Phase 1**: Fast initial 15-rotation retraction via MotionMagic (same as one manual tap) while starting the roller
  - **Phase 2**: Slow DynamicMotionMagic finish to fully retracted position (0.0), re-commanded each cycle until complete
  - Roller cleanup is guaranteed via `finallyDo()` even if the deadline interrupts

## Implementation Details

- Uses `Commands.deadline()` pattern where shooter+indexer is the deadline and slide retraction runs in parallel
- Roller is always stopped on command exit via `finallyDo()`, ensuring proper cleanup on interruption
- Two-phase approach balances speed (initial jump) with precision (slow finish to zero)
- Designed to work seamlessly in both teleop and autonomous contexts

https://claude.ai/code/session_01XiKABjJ1mHNymzn3ebUTk5