### PR TITLE
Update vision method names and enable indexer logging

### DIFF
--- a/src/main/java/frc/robot/commands/AutoHubShootCommand.java
+++ b/src/main/java/frc/robot/commands/AutoHubShootCommand.java
@@ -92,7 +92,7 @@ public class AutoHubShootCommand extends Command {
     @Override
     public void execute() {
         // ── 1. Shooter: update RPM + hood from pose-based distance ───────────
-        double dist = vision.getDistanceToHub();
+        double dist = vision.getDistanceToTargetMeters();
         if (dist > 0) {
             shooter.updateFromDistance(dist);
         }
@@ -101,7 +101,7 @@ public class AutoHubShootCommand extends Command {
         }
 
         // ── 2. Drivetrain: driver translation + pose-based rotation ──────────
-        double angleErrorDeg = vision.getAngleToHub();
+        double angleErrorDeg = vision.getHorizontalAngleDegrees();
         double rot = pid.calculate(angleErrorDeg);
         rot = Math.max(-ROT_MAX_OUTPUT, Math.min(ROT_MAX_OUTPUT, rot));
 

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
@@ -69,7 +69,7 @@ public class IndexerSubsystem extends SubsystemBase {
     // This subclass implements LoggableInputs, which is what Logger.processInputs()
     // needs to write fields to the AdvantageKit log. Using plain IndexerIOInputs
     // here would silently skip all indexer data in AdvantageScope.
-    // private final IndexerIOInputsAutoLogged inputs = new IndexerIOInputsAutoLogged();
+    private final IndexerIOInputsAutoLogged inputs = new IndexerIOInputsAutoLogged();
 
     // ==== State ===============================================================
     private IndexerState currentState = IndexerState.IDLE;


### PR DESCRIPTION
## Summary
This PR updates vision subsystem method calls to use the new API naming convention and enables AdvantageKit logging for the indexer subsystem.

## Key Changes
- **AutoHubShootCommand**: Updated vision method calls to match the refactored API:
  - `vision.getDistanceToHub()` → `vision.getDistanceToTargetMeters()`
  - `vision.getAngleToHub()` → `vision.getHorizontalAngleDegrees()`
- **IndexerSubsystem**: Uncommented the `IndexerIOInputsAutoLogged` field to enable proper logging of indexer data to AdvantageScope

## Implementation Details
The vision method name changes provide clearer, more descriptive API naming that better indicates what data is being retrieved (distance in meters, horizontal angle in degrees). The indexer logging change ensures that indexer state and sensor data are properly captured in the AdvantageKit log for debugging and analysis.

https://claude.ai/code/session_01C2FaxsBiQXiBxauivjU1HQ