### PR TITLE
Enable vision alignment state machine and distance calculations

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -212,21 +212,24 @@ public final class Constants {
     // 25 degrees is a common starting point for angled vision setups, but should be measured for accuracy.
     public static final double CAMERA_ANGLE_DEGREES = 25.0;  // TODO: Measure actual angle
 
+    /** Height of AprilTag center from floor in meters */
+    public static final double APRILTAG_HEIGHT_METERS = 1.45;  // TODO: Update for 2026 game
+
     // Alignment tolerances
     /** Tolerance for horizontal alignment in degrees */
-    // public static final double ALIGNMENT_TOLERANCE_DEGREES = 2.0;
+    public static final double ALIGNMENT_TOLERANCE_DEGREES = 2.0;
 
     /** Minimum target area to consider target valid (prevents false positives) */
-    // public static final double MIN_TARGET_AREA_PERCENT = 0.1;
+    public static final double MIN_TARGET_AREA_PERCENT = 0.1;
 
     /** Maximum distance to trust vision measurement in meters */
-    // public static final double MAX_DISTANCE_METERS = 8.0;
+    public static final double MAX_DISTANCE_METERS = 8.0;
 
     // Valid tag IDs
     // NOTE: MIN/MAX here are used for general target validation in VisionSubsystem.
     // AlignToHubCommand uses its own tighter filter (tags 23-28) for hub-specific alignment.
-    // public static final int MIN_VALID_TAG_ID = 1;
-    // public static final int MAX_VALID_TAG_ID = 28; // Fixed: was -1, which rejected all tags
+    public static final int MIN_VALID_TAG_ID = 1;
+    public static final int MAX_VALID_TAG_ID = 28;
 
     // Blue hub AprilTag IDs
     // public static final int BLUE_HUB_MIN_TAG_ID = 23;
@@ -238,7 +241,6 @@ public final class Constants {
     // public static final int RED_HUB_MAX_TAG_ID = 6;
 
     // State tracking
-    // /** Time in seconds before considering target "lost" after losing sight */
     public static final double TARGET_TIMEOUT_SECONDS = 0.5;
 
     // == Vision-driven drivetrain rotation ====

--- a/src/main/java/frc/robot/commands/VisionShootCommand.java
+++ b/src/main/java/frc/robot/commands/VisionShootCommand.java
@@ -6,6 +6,8 @@ import com.ctre.phoenix6.swerve.SwerveRequest;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.networktables.DoublePublisher;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.CommandSwerveDrivetrain;
 import frc.robot.subsystems.indexer.IndexerSubsystem;
@@ -74,6 +76,28 @@ public class VisionShootCommand extends Command {
             .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
 
     // =========================================================================
+    // Diagnostics — published to NT so direction-snap issues can be debugged
+    // on the field via Elastic/Shuffleboard.
+    // Key: if rotRate sign is opposite to the desired turn direction, negate
+    // headingErrorDeg (i.e. swap the subtraction order in headingErrorDeg).
+    // =========================================================================
+    private final DoublePublisher ntAngleToHub =
+            NetworkTableInstance.getDefault()
+                    .getTable("VisionShoot").getDoubleTopic("angleToHub_deg").publish();
+    private final DoublePublisher ntCurrentHeading =
+            NetworkTableInstance.getDefault()
+                    .getTable("VisionShoot").getDoubleTopic("currentHeading_deg").publish();
+    private final DoublePublisher ntHeadingError =
+            NetworkTableInstance.getDefault()
+                    .getTable("VisionShoot").getDoubleTopic("headingError_deg").publish();
+    private final DoublePublisher ntRotRate =
+            NetworkTableInstance.getDefault()
+                    .getTable("VisionShoot").getDoubleTopic("rotRate_radps").publish();
+    private final DoublePublisher ntDistance =
+            NetworkTableInstance.getDefault()
+                    .getTable("VisionShoot").getDoubleTopic("distanceToHub_m").publish();
+
+    // =========================================================================
     // Constructor
     // =========================================================================
 
@@ -134,6 +158,17 @@ public class VisionShootCommand extends Command {
                 headingErrorDeg * ROTATIONAL_KP,
                 -MAX_ROT_RAD_PER_SEC,
                 MAX_ROT_RAD_PER_SEC);
+
+        // Publish diagnostics — use Elastic/Shuffleboard to verify direction snap:
+        // • angleToHub and currentHeading should both be sensible field-frame angles
+        // • headingError positive → robot should rotate CCW (left from driver view)
+        // • rotRate positive → CCW in CTRE FieldCentric; if robot turns the WRONG way,
+        //   negate rotRate and file a note in TUNING.md
+        ntAngleToHub.set(angleToHubDeg);
+        ntCurrentHeading.set(currentHeadingDeg);
+        ntHeadingError.set(headingErrorDeg);
+        ntRotRate.set(rotRate);
+        ntDistance.set(distance);
 
         drivetrain.setControl(
                 alignRequest

--- a/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionSubsystem.java
@@ -130,7 +130,7 @@ public class VisionSubsystem extends SubsystemBase {
         Logger.processInputs("Vision", inputs);
 
         // Update state machine
-        // updateAlignmentState();
+        updateAlignmentState();
 
         // Log telemetry
         logTelemetry();
@@ -144,11 +144,70 @@ public class VisionSubsystem extends SubsystemBase {
      * Updates the alignment state based on current vision data.
      * Called automatically in periodic().
      */
-    // private void updateAlignmentState() {
-    //     previousState = currentState;
+    private void updateAlignmentState() {
+        previousState = currentState;
 
-        
-    // }
+        if (inputs.hasTargets && isTargetValid()) {
+            lastTargetSeenTime = Timer.getFPGATimestamp();
+
+            // Cache last known good values for LOST_TARGET grace period
+            lastKnownDistance = calculateDistance();
+            lastKnownHorizontalAngle = Units.radiansToDegrees(inputs.horizontalAngleRadians);
+
+            if (isWithinAlignmentTolerance()) {
+                currentState = AlignmentState.ALIGNED;
+            } else {
+                currentState = AlignmentState.TARGET_ACQUIRED;
+            }
+        } else {
+            double timeSinceLastTarget = Timer.getFPGATimestamp() - lastTargetSeenTime;
+
+            if (timeSinceLastTarget < Constants.Vision.TARGET_TIMEOUT_SECONDS &&
+                    previousState != AlignmentState.NO_TARGET) {
+                currentState = AlignmentState.LOST_TARGET;
+            } else {
+                currentState = AlignmentState.NO_TARGET;
+                lastKnownDistance = 0.0;
+                lastKnownHorizontalAngle = 0.0;
+            }
+        }
+
+        if (currentState != previousState) {
+            Logger.recordOutput("Vision/StateTransition",
+                    previousState.name() + " -> " + currentState.name());
+        }
+    }
+
+    /** Returns true if the current tag ID and target area pass basic sanity checks. */
+    private boolean isTargetValid() {
+        if (inputs.tagId < Constants.Vision.MIN_VALID_TAG_ID ||
+                inputs.tagId > Constants.Vision.MAX_VALID_TAG_ID) {
+            return false;
+        }
+        if (inputs.targetArea < Constants.Vision.MIN_TARGET_AREA_PERCENT) {
+            return false;
+        }
+        double distance = calculateDistance();
+        return distance >= 0.1 && distance <= Constants.Vision.MAX_DISTANCE_METERS;
+    }
+
+    /** Returns true if horizontal tx error is within the shooting tolerance. */
+    private boolean isWithinAlignmentTolerance() {
+        return Math.abs(Units.radiansToDegrees(inputs.horizontalAngleRadians))
+                <= Constants.Vision.ALIGNMENT_TOLERANCE_DEGREES;
+    }
+
+    /**
+     * Calculates distance to target using camera geometry.
+     * distance = (tagHeight - cameraHeight) / tan(cameraAngle + ty)
+     */
+    private double calculateDistance() {
+        double heightDiff = Constants.Vision.APRILTAG_HEIGHT_METERS
+                          - Constants.Vision.CAMERA_HEIGHT_METERS;
+        double angleToTarget = Constants.Vision.CAMERA_ANGLE_DEGREES
+                             + Units.radiansToDegrees(inputs.verticalAngleRadians);
+        return Math.abs(heightDiff / Math.tan(Math.toRadians(angleToTarget)));
+    }
 
 
     // =========================================================================
@@ -210,24 +269,25 @@ public class VisionSubsystem extends SubsystemBase {
 
     /**
      * Calculates distance to target in meters using camera geometry.
-     *
      * Uses the formula: distance = (targetHeight - cameraHeight) / tan(cameraAngle + ty)
-     *
      * For LOST_TARGET state, returns last known distance for smooth transitions.
      *
      * @return Distance to target in meters, or 0 if no target
      */
-    // public double getDistanceToTargetMeters() {
-    //     if (currentState == AlignmentState.NO_TARGET) {
-    //         return 0.0;
-    //     }
+    public double getDistanceToTargetMeters() {
+        if (currentState == AlignmentState.NO_TARGET) {
+            return 0.0;
+        }
+        if (currentState == AlignmentState.LOST_TARGET) {
+            return lastKnownDistance;
+        }
+        return calculateDistance();
+    }
 
-    //     if (currentState == AlignmentState.LOST_TARGET) {
-    //         return lastKnownDistance; // Use last known value during grace period
-    //     }
-
-    //     return calculateDistance();
-    // }
+    /** Returns distance in centimeters (convenience wrapper). */
+    public double getDistanceToTargetCM() {
+        return getDistanceToTargetMeters() * 100.0;
+    }
 
 
     // =========================================================================
@@ -310,6 +370,8 @@ public class VisionSubsystem extends SubsystemBase {
         isAlignedPublisher.set(isAligned());
         tagIdPublisher.set(getTagId());
         targetAreaPublisher.set(inputs.targetArea);
+        distanceMetersPublisher.set(getDistanceToTargetMeters());
+        distanceCmPublisher.set(getDistanceToTargetCM());
         horizontalAnglePublisher.set(getHorizontalAngleDegrees());
         verticalAnglePublisher.set(getVerticalAngleDegrees());
         latencyPublisher.set(inputs.totalLatencyMs);


### PR DESCRIPTION
## Summary
This PR re-enables the vision subsystem's alignment state machine and distance calculation logic that was previously commented out. It also adds diagnostic telemetry publishing to VisionShootCommand to help debug direction-snap issues in the field.

## Key Changes

### VisionSubsystem
- **Uncommented and implemented `updateAlignmentState()`**: Re-enabled the state machine that tracks alignment states (NO_TARGET, LOST_TARGET, TARGET_ACQUIRED, ALIGNED) with proper grace period handling for lost targets
- **Implemented `isTargetValid()`**: Added validation logic to check tag ID range, minimum target area, and distance bounds before considering a target valid
- **Implemented `isWithinAlignmentTolerance()`**: Added check to determine if horizontal angle error is within shooting tolerance
- **Implemented `calculateDistance()`**: Added distance calculation using camera geometry (height difference and angle to target)
- **Uncommented and implemented `getDistanceToTargetMeters()`**: Re-enabled public method to retrieve distance with special handling for LOST_TARGET state (returns last known distance)
- **Added `getDistanceToTargetCM()`**: New convenience wrapper that returns distance in centimeters
- **Enhanced telemetry logging**: Added distance metrics (meters and centimeters) to the periodic telemetry output

### VisionShootCommand
- **Added diagnostic NetworkTable publishers**: Created five new NT publishers to track:
  - `angleToHub_deg`: Target angle in field frame
  - `currentHeading_deg`: Robot's current heading
  - `headingError_deg`: Error between desired and current heading
  - `rotRate_radps`: Calculated rotation rate
  - `distanceToHub_m`: Distance to target
- **Published diagnostics in execute()**: These values are now published every cycle to enable real-time debugging via Elastic/Shuffleboard
- **Added detailed comments**: Included guidance on how to diagnose and fix direction-snap issues using the published diagnostics

### Constants
- **Uncommented vision configuration constants**:
  - `ALIGNMENT_TOLERANCE_DEGREES = 2.0`
  - `MIN_TARGET_AREA_PERCENT = 0.1`
  - `MAX_DISTANCE_METERS = 8.0`
  - `MIN_VALID_TAG_ID = 1` and `MAX_VALID_TAG_ID = 28`
- **Added `APRILTAG_HEIGHT_METERS = 1.45`**: New constant for AprilTag center height (marked as TODO for 2026 game)
- **Kept `TARGET_TIMEOUT_SECONDS = 0.5`**: Grace period for lost target state

## Implementation Details
- The state machine properly handles target loss with a configurable timeout period, returning cached values during the grace period for smooth transitions
- Distance calculations use proper unit conversions (radians to degrees) and account for camera mounting angle
- Diagnostic telemetry includes a note about potential direction-snap issues: if the robot turns the wrong way, the `rotRate` sign may need to be negated

https://claude.ai/code/session_014eRXVQwgVW1SsvFV4HhsyV