### PR TITLE
Refactor indexer feed commands to use direct method calls

### DIFF
--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -87,9 +87,7 @@ public class FuelCommands {
                     shooter.prepareToShoot();
                 }, shooter),
                 Commands.waitUntil(shooter::isReady).withTimeout(3.0),
-                Commands.run(() -> {
-                    indexer.feed();
-                }, indexer))
+                indexer.feed())
                 .finallyDo(() -> {
                     indexer.indexerStop();
                     indexer.conveyorStop();
@@ -248,9 +246,7 @@ public class FuelCommands {
                     shooter.prepareToShoot();
                 }, shooter),
                 Commands.waitUntil(shooter::isReady).withTimeout(3.0),
-                Commands.run(() -> {
-                    indexer.feed();
-                }, indexer))
+                indexer.feed())
                 .finallyDo(() -> {
                     indexer.indexerStop();
                     indexer.conveyorStop();
@@ -360,7 +356,8 @@ public class FuelCommands {
             // 4. Feed: aligned within 2° AND flywheel/hood settled
             boolean aligned = Math.abs(headingErrorDeg) <= Constants.Vision.ALIGNMENT_TOLERANCE_DEGREES;
             if (aligned && shooter.isReady()) {
-                indexer.feed();
+                indexer.conveyorForward();
+                indexer.indexerForward();
             } else {
                 indexer.indexerStop();
                 indexer.conveyorStop();


### PR DESCRIPTION
## Summary
Refactored indexer feeding logic to use direct method calls instead of wrapping them in `Commands.run()`, and updated `poseAlignAndShoot` to explicitly call individual indexer methods for better control.

## Key Changes
- Replaced `Commands.run(() -> { indexer.feed(); }, indexer)` with direct `indexer.feed()` calls in `shootWithPreset()` and `shootPass()` methods
- Updated `poseAlignAndShoot()` to call `indexer.conveyorForward()` and `indexer.indexerForward()` separately instead of the combined `indexer.feed()` method
- This provides more granular control over indexer behavior during pose-aligned shooting

## Implementation Details
- The changes simplify command composition by removing unnecessary command wrapping
- In `poseAlignAndShoot()`, the explicit separation of conveyor and indexer forward calls allows for independent control of these mechanisms during alignment-based shooting
- All three methods maintain their existing error handling and cleanup logic via `finallyDo()` blocks

https://claude.ai/code/session_01TfKrTqXunF6vz7euYktjbj