### PR TITLE
Remove intake requirement from poseAlignAndShoot

### DIFF
--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -439,7 +439,7 @@ public class FuelCommands {
                 fuelPumpTimer.reset(); // reset so pump starts fresh when shooter becomes ready
             }
 
-        }, shooter, indexer, intake, drivetrain)
+        }, shooter, indexer, drivetrain)
                 .beforeStarting(Commands.runOnce(() -> {
                     shooter.beginSpinUp();
                     fuelPumpTimer.reset();


### PR DESCRIPTION
## Summary
Removed `intake` subsystem requirement from `poseAlignAndShoot` command to allow concurrent execution of fuel pump and retract commands.

## Changes
- Removed `intake` parameter from command requirements in `FuelCommands.java`
- This enables the intake to operate independently without blocking other fuel-related commands