### PR TITLE
Improve fuel pump cycling with new fuelPumpCycle command

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -126,7 +126,7 @@ public class RobotContainer {
                 () -> -driver.getLeftY() * MaxSpeed,
                 () -> -driver.getLeftX() * MaxSpeed)); 
         
-        driver.rightBumper().whileTrue(intake.fuelPumpBasic());
+        driver.rightBumper().whileTrue(intake.fuelPumpCycle());
 
         driver.leftTrigger(0.5).whileTrue(intake.intakeFuel());
         driver.leftBumper().whileTrue(intake.compressFuelHeld());

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java
@@ -69,7 +69,7 @@ public class IntakeIOHardware implements IntakeIO {
             config.SoftwareLimitSwitch.ForwardSoftLimitEnable = true;
             config.SoftwareLimitSwitch.ForwardSoftLimitThreshold = 44.25;
             config.SoftwareLimitSwitch.ReverseSoftLimitEnable = true;
-            config.SoftwareLimitSwitch.ReverseSoftLimitThreshold = 0.0;
+            config.SoftwareLimitSwitch.ReverseSoftLimitThreshold = -0.5; // Allow MotionMagic to reach and hold 0.0 without the soft limit reducing output early
 
             /* Tune PID values for position control of the Slide motor */
             config.Slot0.kP = 2.0;

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -372,6 +372,31 @@ public class IntakeSubsystem extends SubsystemBase {
                 .withName("FuelPump");
     }
 
+    /**
+     * Continuously cycles the slides between SLIDE_BOUNCE_DOWN_POS and SLIDE_BOUNCE_UP_POS
+     * while running the roller, for as long as the button is held.
+     *
+     * Use with whileTrue() — the command runs indefinitely and stops cleanly on release.
+     * Replaces fuelPumpBasic().repeatedly() which had roller-stop gaps between cycles.
+     */
+    public Command fuelPumpCycle() {
+        Timer cycleTimer = new Timer();
+        return Commands.run(() -> {
+            runRoller();
+            double t = cycleTimer.get();
+            if (t < 0.5) {
+                setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_DOWN_POS);
+            } else if (t < 1.0) {
+                setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_UP_POS);
+            } else {
+                cycleTimer.restart(); // reset + start, so next cycle begins immediately
+            }
+        }, this)
+                .beforeStarting(cycleTimer::restart)
+                .finallyDo(this::stopRoller)
+                .withName("FuelPumpCycle");
+    }
+
     // Loopable and repeatable version of fuelPump() for more manual control over timing and cycles.
     public Command fuelPumpBasic() {
         return Commands.sequence(


### PR DESCRIPTION
## Summary
Replaces the fuel pump control mechanism with a new `fuelPumpCycle()` command that provides continuous, smooth cycling of the intake slides without gaps in roller operation.

## Key Changes
- **Added `fuelPumpCycle()` command** in `IntakeSubsystem`: A new command that continuously cycles slides between `SLIDE_BOUNCE_DOWN_POS` and `SLIDE_BOUNCE_UP_POS` on a 1-second timer (0.5s down, 0.5s up) while keeping the roller running throughout
- **Updated driver control binding**: Changed `driver.rightBumper()` from `fuelPumpBasic()` to `fuelPumpCycle()` for improved fuel pump operation
- **Adjusted slide soft limit**: Modified the reverse soft limit threshold from `0.0` to `-0.5` to allow MotionMagic to properly reach and hold the 0.0 position without early output reduction

## Implementation Details
- The new `fuelPumpCycle()` uses a `Timer` to manage the cycling phases, automatically restarting after each complete cycle
- The command is designed to work with `whileTrue()`, running indefinitely while the button is held and stopping cleanly on release
- Eliminates the roller-stop gaps that occurred with the previous `fuelPumpBasic().repeatedly()` approach
- Properly initializes the timer on command start and stops the roller on command end via lifecycle methods

https://claude.ai/code/session_01Ca3XbcQVVyA3W8kciyLCuf