### PR TITLE
Add fuelPumpCycleAuto command for autonomous trajectory events

### DIFF
--- a/src/main/java/frc/robot/AutoRoutines.java
+++ b/src/main/java/frc/robot/AutoRoutines.java
@@ -102,6 +102,7 @@ public class AutoRoutines {
                                 ));
                 // Routine Events
                 StartRMid.atTime("Intake").onTrue(m_intake.intakeFuelTimer(5));
+                // StartRMid.atTime("FuelPump").onTrue(m_intake.fuelPumpCycleAuto(2.0));
 
                 // Vision Shot
                 StartRMid.atTime("Shoot").onTrue(FuelCommands.Auto. poseAlignAndShoot(m_shooter, m_indexer, m_drivetrain, 3.0));

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -397,6 +397,32 @@ public class IntakeSubsystem extends SubsystemBase {
                 .withName("FuelPumpCycle");
     }
 
+    /**
+     * Runs the fuel pump cycle (bouncing slides + roller) for a fixed duration.
+     * Ends naturally after {@code seconds}, making it safe for autonomous and
+     * Choreo event linking via {@code trajectory.atTime("FuelPump").onTrue(...)}.
+     *
+     * @param seconds How long to run the pump cycle.
+     */
+    public Command fuelPumpCycleAuto(double seconds) {
+        Timer cycleTimer = new Timer();
+        return Commands.run(() -> {
+            runRoller();
+            double t = cycleTimer.get();
+            if (t < 0.5) {
+                setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_DOWN_POS);
+            } else if (t < 1.0) {
+                setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_UP_POS);
+            } else {
+                cycleTimer.restart();
+            }
+        }, this)
+                .beforeStarting(cycleTimer::restart)
+                .withTimeout(seconds)
+                .finallyDo(this::stopRoller)
+                .withName("FuelPumpCycleAuto");
+    }
+
     // Loopable and repeatable version of fuelPump() for more manual control over timing and cycles.
     public Command fuelPumpBasic() {
         return Commands.sequence(


### PR DESCRIPTION
## Summary
Added a new `fuelPumpCycleAuto` command to the IntakeSubsystem that runs the fuel pump cycle for a fixed duration, enabling safe integration with Choreo trajectory event linking in autonomous routines.

## Key Changes
- **New `fuelPumpCycleAuto(double seconds)` command**: Executes the fuel pump cycle (bouncing slides + roller) with automatic timeout after a specified duration
  - Uses an internal Timer to manage the bounce cycle (0.5s down, 0.5s up, repeat)
  - Automatically restarts the bounce pattern when the 1-second cycle completes
  - Ends naturally via `withTimeout()`, making it safe for autonomous and Choreo event linking
  - Ensures roller is stopped via `finallyDo()` cleanup
  
- **Updated AutoRoutines.java**: Added commented example showing how to link the new command to trajectory events via `atTime("FuelPump").onTrue(m_intake.fuelPumpCycleAuto(2.0))`

## Implementation Details
- The command uses a Timer that automatically restarts after each complete bounce cycle (1 second)
- The overall command respects the `seconds` timeout parameter, allowing flexible duration control
- Roller runs continuously throughout the cycle
- Proper cleanup ensures the roller stops when the command ends, regardless of how it terminates

https://claude.ai/code/session_01EPDu5Di6CwCxhQpc1o7XT5