### PR TITLE
Add sensor-gated fuelPumpCycleSensor for autonomous use

### DIFF
--- a/src/main/java/frc/robot/AutoRoutines.java
+++ b/src/main/java/frc/robot/AutoRoutines.java
@@ -102,7 +102,10 @@ public class AutoRoutines {
                                 ));
                 // Routine Events
                 StartRMid.atTime("Intake").onTrue(m_intake.intakeFuelTimer(5));
+                // Option A — fixed timer:
                 // StartRMid.atTime("FuelPump").onTrue(m_intake.fuelPumpCycleAuto(2.0));
+                // Option B — sensor-gated (waits for first detection, stops when chute clears):
+                // StartRMid.atTime("FuelPump").onTrue(m_intake.fuelPumpCycleSensor(m_indexer));
 
                 // Vision Shot
                 StartRMid.atTime("Shoot").onTrue(FuelCommands.Auto. poseAlignAndShoot(m_shooter, m_indexer, m_drivetrain, 3.0));

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -15,6 +15,7 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
 import frc.robot.Constants;
+import frc.robot.subsystems.indexer.IndexerSubsystem;
 
 public class IntakeSubsystem extends SubsystemBase {
 
@@ -421,6 +422,50 @@ public class IntakeSubsystem extends SubsystemBase {
                 .withTimeout(seconds)
                 .finallyDo(this::stopRoller)
                 .withName("FuelPumpCycleAuto");
+    }
+
+    /**
+     * Sensor-gated fuel pump for autonomous / Choreo event linking.
+     *
+     * <p>Phase 1 — WAIT (no subsystem held): polls {@code indexer.isFuelDetected()}.
+     * While waiting, IntakeSubsystem is free so an {@code intakeFuelTimer} can run
+     * in parallel without conflict.
+     *
+     * <p>Phase 2 — PUMP (claims IntakeSubsystem): bounces slides + runs roller
+     * until {@code indexer.isChuteEmpty()} is true (fuel seen then gone for
+     * FUEL_CLEAR_TIME seconds).
+     *
+     * <p>A hard-stop timeout prevents the command from hanging if the sensor lies
+     * or fuel never clears.
+     *
+     * <p>Usage: {@code trajectory.atTime("FuelPump").onTrue(m_intake.fuelPumpCycleSensor(m_indexer));}
+     *
+     * @param indexer   The IndexerSubsystem that owns the chute CANrange sensor.
+     */
+    public Command fuelPumpCycleSensor(IndexerSubsystem indexer) {
+        Timer cycleTimer = new Timer();
+        return Commands.sequence(
+            // Phase 1: wait for first fuel — no subsystem required, intake can run freely
+            Commands.runOnce(indexer::resetChuteTracking),
+            Commands.waitUntil(indexer::isFuelDetected),
+            // Phase 2: pump until chute clears (or hard timeout)
+            Commands.run(() -> {
+                runRoller();
+                double t = cycleTimer.get();
+                if (t < 0.5) {
+                    setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_DOWN_POS);
+                } else if (t < 1.0) {
+                    setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_UP_POS);
+                } else {
+                    cycleTimer.restart();
+                }
+            }, this)
+                .beforeStarting(cycleTimer::restart)
+                .until(indexer::isChuteEmpty)
+                .withTimeout(5.0) // hard stop — tune or remove once reliable
+        )
+        .finallyDo(this::stopRoller)
+        .withName("FuelPumpCycleSensor");
     }
 
     // Loopable and repeatable version of fuelPump() for more manual control over timing and cycles.


### PR DESCRIPTION
Waits for isFuelDetected() before claiming IntakeSubsystem, so an intakeFuelTimer can run in parallel without subsystem conflict. Once fuel arrives, bounces slides until isChuteEmpty() then stops cleanly. Includes a 5s hard-stop timeout as a safety net.

Also resets chuteTracking on start so hasSeenFuel is fresh each run.

https://claude.ai/code/session_01EPDu5Di6CwCxhQpc1o7XT5