### PR TITLE
Extend fuelPumpCycleSensor inward sweep to reach straggler balls

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -54,6 +54,12 @@ public final class Constants {
     public static final double SLIDE_BOUNCE_DOWN_POS = 40.0;
     /** Bounce UP: roller lifted ~5 rotations toward bumpers — high position for bump agitation. TODO: Tune */
     public static final double SLIDE_BOUNCE_UP_POS   = 30.0;
+    /**
+     * Sensor-pump UP position: deeper inward sweep used by fuelPumpCycleSensor only.
+     * Extends farther than SLIDE_BOUNCE_UP_POS to push straggler balls into conveyor range
+     * so the chute sensor can detect them. ~half of full extension. TODO: Tune
+     */
+    public static final double SLIDE_PUMP_SENSOR_UP_POS = 22.0;
 
 
     // TODO Tune the roller voltages

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -455,7 +455,7 @@ public class IntakeSubsystem extends SubsystemBase {
                 if (t < 0.5) {
                     setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_DOWN_POS);
                 } else if (t < 1.0) {
-                    setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_UP_POS);
+                    setSlidesToPosition(Constants.Intake.SLIDE_PUMP_SENSOR_UP_POS);
                 } else {
                     cycleTimer.restart();
                 }


### PR DESCRIPTION
Adds Constants.Intake.SLIDE_PUMP_SENSOR_UP_POS = 22.0 — a deeper inward sweep position used only by fuelPumpCycleSensor. Replaces SLIDE_BOUNCE_UP_POS (30) in the sensor pump phase so the bounce reaches the conveyor zone, pushing straggler balls into detection range rather than leaving them stranded outside the sensor window.

SLIDE_BOUNCE_UP_POS (30) unchanged — teleop fuelPumpCycle unaffected.

https://claude.ai/code/session_01EPDu5Di6CwCxhQpc1o7XT5