### PR TITLE
Add jam recovery to fuel pump cycle commands

### DIFF
--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -415,22 +415,33 @@ public class IntakeSubsystem extends SubsystemBase {
      * Ends naturally after {@code seconds}, making it safe for autonomous and
      * Choreo event linking via {@code trajectory.atTime("FuelPump").onTrue(...)}.
      *
+     * Jam recovery: same as fuelPumpCycle() — if the slide hasn't reached
+     * SLIDE_BOUNCE_UP_POS within 0.5 s, the cycle restarts to DOWN to dislodge.
+     *
      * @param seconds How long to run the pump cycle.
      */
     public Command fuelPumpCycleAuto(double seconds) {
         Timer cycleTimer = new Timer();
+        Timer jamTimer = new Timer();
         return Commands.run(() -> {
             runRoller();
             double t = cycleTimer.get();
             if (t < 0.5) {
                 setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_DOWN_POS);
-            } else if (t < 1.0) {
-                setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_UP_POS);
+                jamTimer.restart();
             } else {
-                cycleTimer.restart();
+                setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_UP_POS);
+                boolean notNearUp = Math.abs(inputs.slidePositionRotations
+                        - Constants.Intake.SLIDE_BOUNCE_UP_POS) > 2.0;
+                if (notNearUp && jamTimer.get() >= 0.5) {
+                    cycleTimer.restart();
+                    jamTimer.restart();
+                } else if (t >= 1.0) {
+                    cycleTimer.restart();
+                }
             }
         }, this)
-                .beforeStarting(cycleTimer::restart)
+                .beforeStarting(() -> { cycleTimer.restart(); jamTimer.restart(); })
                 .withTimeout(seconds)
                 .finallyDo(this::stopRoller)
                 .withName("FuelPumpCycleAuto");
@@ -456,6 +467,7 @@ public class IntakeSubsystem extends SubsystemBase {
      */
     public Command fuelPumpCycleSensor(IndexerSubsystem indexer) {
         Timer cycleTimer = new Timer();
+        Timer jamTimer = new Timer();
         return Commands.sequence(
             // Phase 1: wait for first fuel — no subsystem required, intake can run freely
             Commands.runOnce(indexer::resetChuteTracking),
@@ -466,13 +478,20 @@ public class IntakeSubsystem extends SubsystemBase {
                 double t = cycleTimer.get();
                 if (t < 0.5) {
                     setSlidesToPosition(Constants.Intake.SLIDE_BOUNCE_DOWN_POS);
-                } else if (t < 1.0) {
-                    setSlidesToPosition(Constants.Intake.SLIDE_PUMP_SENSOR_UP_POS);
+                    jamTimer.restart();
                 } else {
-                    cycleTimer.restart();
+                    setSlidesToPosition(Constants.Intake.SLIDE_PUMP_SENSOR_UP_POS);
+                    boolean notNearUp = Math.abs(inputs.slidePositionRotations
+                            - Constants.Intake.SLIDE_PUMP_SENSOR_UP_POS) > 2.0;
+                    if (notNearUp && jamTimer.get() >= 0.5) {
+                        cycleTimer.restart();
+                        jamTimer.restart();
+                    } else if (t >= 1.0) {
+                        cycleTimer.restart();
+                    }
                 }
             }, this)
-                .beforeStarting(cycleTimer::restart)
+                .beforeStarting(() -> { cycleTimer.restart(); jamTimer.restart(); })
                 .until(indexer::isChuteEmpty)
                 .withTimeout(10.0) // hard stop — tune or remove once reliable
         )


### PR DESCRIPTION
## Summary
Enhanced the fuel pump cycle commands with automatic jam detection and recovery. When the intake slide fails to reach its target position within 0.5 seconds during the UP phase, the cycle now automatically restarts to the DOWN position to dislodge the jam.

## Key Changes
- Added `jamTimer` to track time spent in the UP phase for all three fuel pump cycle variants:
  - `fuelPumpCycle()` — manual/teleop version
  - `fuelPumpCycleAuto()` — autonomous version with timeout
  - `fuelPumpCycleSensor()` — sensor-based version with indexer coordination

- Implemented jam detection logic that checks:
  - If slide position is more than 2.0 rotations away from target UP position
  - If 0.5 seconds have elapsed in the UP phase without reaching target
  - Automatically restarts cycle to DOWN position when jam is detected

- Updated initialization to reset both timers at command start

## Implementation Details
- `jamTimer` is reset whenever entering the DOWN phase, ensuring it only measures time during the UP phase
- Jam detection uses absolute position difference (`Math.abs(inputs.slidePositionRotations - targetPos) > 2.0`) to account for mechanical tolerance
- Normal cycle completion (reaching 1.0 second total time) still works as before
- Jam recovery takes priority over normal cycle timing, immediately restarting when detected

https://claude.ai/code/session_01926dLps7TqEfHFytsnj63n