### PR TITLE
Add botpose reset command for odometry recovery

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,8 +11,6 @@ import com.ctre.phoenix6.swerve.SwerveRequest;
 
 import choreo.auto.AutoChooser;
 import choreo.auto.AutoFactory;
-import edu.wpi.first.math.util.Units;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
@@ -28,7 +26,6 @@ import frc.robot.subsystems.intake.IntakeIOHardware;
 import frc.robot.subsystems.shooter.ShooterIOHardware;
 import frc.robot.subsystems.shooter.ShooterSubsystem;
 import frc.robot.subsystems.led.LedSubsystem;
-import frc.robot.subsystems.vision.LimelightHelpers;
 import frc.robot.subsystems.vision.VisionIOLimelight;
 import frc.robot.subsystems.vision.VisionSubsystem;
 
@@ -114,25 +111,7 @@ public class RobotContainer {
         driver.start().onTrue(drivetrain.runOnce(drivetrain::seedFieldCentric));
 
         // Back: Reset odometry to Limelight botpose (use when robot rides up on a ball and wheels lose contact)
-        driver.back().onTrue(Commands.runOnce(() -> {
-            var driveState = drivetrain.getState();
-            double omegaRps = Units.radiansToRotations(driveState.Speeds.omegaRadiansPerSecond);
-            if (Math.abs(omegaRps) >= 2.0) {
-                SmartDashboard.putString("BotposeReset", "SKIPPED (spinning)");
-                return;
-            }
-            double headingDeg = driveState.Pose.getRotation().getDegrees();
-            LimelightHelpers.SetRobotOrientation(
-                    Constants.Vision.LIMELIGHT4_NAME, headingDeg, 0, 0, 0, 0, 0);
-            var llMeasurement = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(
-                    Constants.Vision.LIMELIGHT4_NAME);
-            if (llMeasurement != null && llMeasurement.tagCount > 0) {
-                drivetrain.resetPose(llMeasurement.pose);
-                SmartDashboard.putString("BotposeReset", "OK");
-            } else {
-                SmartDashboard.putString("BotposeReset", "SKIPPED (no tags)");
-            }
-        }, drivetrain));
+        driver.back().onTrue(drivetrain.resetPoseFromVisionCommand());
 
         drivetrain.registerTelemetry(logger::telemeterize);
 
@@ -187,25 +166,7 @@ public class RobotContainer {
         operator.leftBumper().whileTrue(intake.retractSlidesStack());
 
         // Back (View ⧉): Reset odometry to botpose — use when robot rides up on a ball
-        operator.back().onTrue(Commands.runOnce(() -> {
-            var driveState = drivetrain.getState();
-            double omegaRps = Units.radiansToRotations(driveState.Speeds.omegaRadiansPerSecond);
-            if (Math.abs(omegaRps) >= 2.0) {
-                SmartDashboard.putString("BotposeReset", "SKIPPED (spinning)");
-                return;
-            }
-            double headingDeg = driveState.Pose.getRotation().getDegrees();
-            LimelightHelpers.SetRobotOrientation(
-                    Constants.Vision.LIMELIGHT4_NAME, headingDeg, 0, 0, 0, 0, 0);
-            var llMeasurement = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(
-                    Constants.Vision.LIMELIGHT4_NAME);
-            if (llMeasurement != null && llMeasurement.tagCount > 0) {
-                drivetrain.resetPose(llMeasurement.pose);
-                SmartDashboard.putString("BotposeReset", "OK");
-            } else {
-                SmartDashboard.putString("BotposeReset", "SKIPPED (no tags)");
-            }
-        }, drivetrain));
+        operator.back().onTrue(drivetrain.resetPoseFromVisionCommand());
 
         // FIXME Add a reverse indexer on start button for operator
 

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -20,15 +20,19 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.DriverStation.Alliance;
 import edu.wpi.first.wpilibj.Notifier;
 import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Subsystem;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 
+import frc.robot.Constants;
 import frc.robot.generated.TunerConstants.TunerSwerveDrivetrain;
+import frc.robot.subsystems.vision.LimelightHelpers;
 
 /**
  * Class that extends the Phoenix 6 SwerveDrivetrain class and implements
@@ -297,6 +301,38 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
                 .withRotationalRate(0));
         });
     }
+    /**
+     * Returns a command that resets the robot pose to the Limelight MegaTag2 botpose estimate.
+     * <p>
+     * Use this when the robot rides up on a ball and the wheels lose ground contact,
+     * corrupting wheel odometry. The reset is skipped if the robot is spinning too fast
+     * (>= 2.0 rot/s) — a stale heading fed to MegaTag2 would produce a bad pose estimate.
+     * Result is published to SmartDashboard under "BotposeReset" for drive-team feedback.
+     *
+     * @return Command (requires drivetrain)
+     */
+    public Command resetPoseFromVisionCommand() {
+        return runOnce(() -> {
+            var driveState = getState();
+            double omegaRps = Units.radiansToRotations(driveState.Speeds.omegaRadiansPerSecond);
+            if (Math.abs(omegaRps) >= 2.0) {
+                SmartDashboard.putString("BotposeReset", "SKIPPED (spinning)");
+                return;
+            }
+            double headingDeg = driveState.Pose.getRotation().getDegrees();
+            LimelightHelpers.SetRobotOrientation(
+                    Constants.Vision.LIMELIGHT4_NAME, headingDeg, 0, 0, 0, 0, 0);
+            var llMeasurement = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(
+                    Constants.Vision.LIMELIGHT4_NAME);
+            if (llMeasurement != null && llMeasurement.tagCount > 0) {
+                resetPose(llMeasurement.pose);
+                SmartDashboard.putString("BotposeReset", "OK");
+            } else {
+                SmartDashboard.putString("BotposeReset", "SKIPPED (no tags)");
+            }
+        });
+    }
+
     @Override
     public void periodic() {
         /*


### PR DESCRIPTION
## Summary
Implements a vision-based odometry reset command to recover from wheel slippage when the robot rides up on a ball during gameplay.

## Changes
- **CommandSwerveDrivetrain**: Added `resetPoseFromVisionCommand()` factory method that:
  - Queries Limelight MegaTag2 botpose estimate
  - Includes rotation gate (skips if robot spinning ≥ 2.0 rot/s)
  - Publishes reset status to SmartDashboard for drive-team feedback
  - Requires valid tag detection to proceed

- **RobotContainer**: Bound reset command to Back button on both driver and operator controllers for easy access during match

## Testing
Verify command executes safely and correctly resets odometry when tags are visible and rotation is within gate threshold.