### PR TITLE
Add vision checkpoint odometry correction for autonomous routines

### DIFF
--- a/src/main/java/frc/robot/AutoRoutines.java
+++ b/src/main/java/frc/robot/AutoRoutines.java
@@ -75,6 +75,8 @@ public class AutoRoutines {
                                 Commands.sequence(
                                                 RtTrench_Mid.resetOdometry(), // Always reset odometry first
                                                 RtTrench_Mid.cmd(), // Follow the path
+                                                // Vision checkpoint: require >=2 tags at segment boundary for high-confidence reset
+                                                m_drivetrain.resetPoseFromVisionCommand(2),
                                                 RtMid_Trench.cmd() // Follow the path
 
                                 ));
@@ -97,6 +99,8 @@ public class AutoRoutines {
                                 Commands.sequence(
                                                 RtTrench_Mid.resetOdometry(), // Always reset odometry first
                                                 RtTrench_Mid.cmd(), // Follow the path
+                                                // Vision checkpoint: require >=2 tags at segment boundary for high-confidence reset
+                                                m_drivetrain.resetPoseFromVisionCommand(2),
                                                 RtMid_Ramp.cmd() // Follow the path
 
                                 ));

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -15,6 +15,7 @@ import com.ctre.phoenix6.HootAutoReplay;
 
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -67,7 +68,10 @@ public class Robot extends LoggedRobot {
         var llMeasurement = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(Constants.Vision.LIMELIGHT4_NAME);
         if (llMeasurement != null && llMeasurement.tagCount > 0 && Math.abs(omegaRps) < 2.0) {
             double dist = llMeasurement.avgTagDist; // meters
-            double xyStdDev = 0.10 * Math.pow(dist, 2.0); // trust drops fast with distance
+            // Tighten trust during autonomous (0.05) vs teleop (0.10) so the Kalman filter
+            // pulls harder toward vision when wheel odometry is most critical.
+            double stdDevScale = DriverStation.isAutonomous() ? 0.05 : 0.10;
+            double xyStdDev = stdDevScale * Math.pow(dist, 2.0); // trust drops fast with distance
             m_robotContainer.drivetrain.addVisionMeasurement(
                     llMeasurement.pose,
                     llMeasurement.timestampSeconds,

--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -312,6 +312,24 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
      * @return Command (requires drivetrain)
      */
     public Command resetPoseFromVisionCommand() {
+        return resetPoseFromVisionCommand(1);
+    }
+
+    /**
+     * Returns a command that resets the robot pose to the Limelight MegaTag2 botpose estimate,
+     * requiring at least {@code minTagCount} tags for the reset to proceed.
+     * <p>
+     * Use {@code minTagCount = 2} during autonomous for higher-confidence resets at segment
+     * boundaries — two visible tags constrain both translation and heading, so the estimate
+     * is far more reliable than a single-tag fix.
+     * <p>
+     * The reset is still skipped if the robot is spinning >= 2.0 rot/s.
+     *
+     * @param minTagCount Minimum number of AprilTags required to accept the estimate (1 for
+     *                    teleop driver reset, 2+ recommended for autonomous checkpoints)
+     * @return Command (requires drivetrain)
+     */
+    public Command resetPoseFromVisionCommand(int minTagCount) {
         return runOnce(() -> {
             var driveState = getState();
             double omegaRps = Units.radiansToRotations(driveState.Speeds.omegaRadiansPerSecond);
@@ -324,11 +342,13 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
                     Constants.Vision.LIMELIGHT4_NAME, headingDeg, 0, 0, 0, 0, 0);
             var llMeasurement = LimelightHelpers.getBotPoseEstimate_wpiBlue_MegaTag2(
                     Constants.Vision.LIMELIGHT4_NAME);
-            if (llMeasurement != null && llMeasurement.tagCount > 0) {
+            if (llMeasurement != null && llMeasurement.tagCount >= minTagCount) {
                 resetPose(llMeasurement.pose);
-                SmartDashboard.putString("BotposeReset", "OK");
+                SmartDashboard.putString("BotposeReset", "OK (" + llMeasurement.tagCount + " tags)");
             } else {
-                SmartDashboard.putString("BotposeReset", "SKIPPED (no tags)");
+                int count = (llMeasurement != null) ? llMeasurement.tagCount : 0;
+                SmartDashboard.putString("BotposeReset",
+                        "SKIPPED (tags: " + count + " < " + minTagCount + ")");
             }
         });
     }


### PR DESCRIPTION
- CommandSwerveDrivetrain: overload resetPoseFromVisionCommand(minTagCount) so callers can require >=2 tags for higher-confidence resets; the no-arg version still accepts any single tag (existing teleop behaviour). SmartDashboard feedback now reports the actual tag count on success or the shortfall on skip.

- AutoRoutines: insert m_drivetrain.resetPoseFromVisionCommand(2) at the segment boundary in both RtTrench_Mid_Trench_Splits and RtTrench_Mid_Ramp_Splits. This forces a hard odometry correction between path segments using MegaTag2 when at least two tags are visible, clearing accumulated wheel-odometry drift before the second leg near field elements.

- Robot.java: tighten Kalman vision std-dev scale from 0.10 to 0.05 during autonomous (DriverStation.isAutonomous()), giving the filter twice as much trust in the MegaTag2 estimate when accurate localization matters most. Teleop continues to use 0.10.

https://claude.ai/code/session_01NfBsW2vKdCL7zt1ZzMNLTi