### PR TITLE
Add NT heading error telemetry to poseAlignAndShoot

### DIFF
--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -440,6 +440,15 @@ public class FuelCommands {
             final SwerveRequest.FieldCentric alignRequest = new SwerveRequest.FieldCentric()
                     .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
 
+            // NT publisher: "Auto/PoseAlign/HeadingError_deg"
+            // Shows live heading error during poseAlignAndShoot (odometry-based, no vision).
+            // Use in Elastic to diagnose whether the 1° tolerance is reachable in auto.
+            // Goes to 0 when pointed at hub; fires when |error| ≤ ALIGNMENT_TOLERANCE_DEGREES.
+            final DoublePublisher ntPoseAlignHeadingError = NetworkTableInstance.getDefault()
+                    .getTable("Auto/PoseAlign")
+                    .getDoubleTopic("HeadingError_deg")
+                    .publish();
+
             return Commands.sequence(
                     // Phase 1: rotate to hub + spin up — both must be ready before feeding
                     Commands.deadline(
@@ -476,6 +485,7 @@ public class FuelCommands {
                                         - pose.getRotation().getDegrees();
                                 while (headingErrorDeg >  180) headingErrorDeg -= 360;
                                 while (headingErrorDeg < -180) headingErrorDeg += 360;
+                                ntPoseAlignHeadingError.set(headingErrorDeg);
                                 double rotRate = MathUtil.clamp(
                                         headingErrorDeg * Constants.Vision.ROTATIONAL_KP,
                                         -Constants.Vision.MAX_ALIGNMENT_ROTATION_RAD_PER_SEC,


### PR DESCRIPTION
## Summary
- Publishes `Auto/PoseAlign/HeadingError_deg` to NetworkTables every loop tick during Phase 1 of `poseAlignAndShoot`
- Published from the rotating `Commands.run` deadline (50 Hz), not the `waitUntil` lambda
- Kept in its own `Auto/PoseAlign` table — distinct from the vision-based `Vision/headingError_deg`

## Why
After competition we determined `.withTimeout(1.0)` was required for `poseAlignAndShoot` to fire at all. Without it, the `waitUntil` condition (heading within 1° AND `shooter.isReady()`) was never satisfied and the robot never fed. The timeout is a workaround — this telemetry lets us see *why* by showing whether heading error actually converges to within `ALIGNMENT_TOLERANCE_DEGREES` (1°) during auto.

## Test plan
- [ ] Deploy and run an auto path that includes `poseAlignAndShoot`
- [ ] Open Elastic dashboard, add a graph for `Auto/PoseAlign/HeadingError_deg`
- [ ] Verify value decreases toward 0 as robot rotates to hub
- [ ] Note the minimum value reached — if it oscillates around ±1.5° and never crosses ±1°, loosen `ALIGNMENT_TOLERANCE_DEGREES`
- [ ] Cross-reference with `Shooter/IsReady` to confirm both conditions during the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)