### PR TITLE
Remove slide-position guard from intake roller controls

### DIFF
--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -138,19 +138,11 @@ public class IntakeSubsystem extends SubsystemBase {
     // Roller
 
     public void runRoller() {
-        if (!isSlidePastHome()) {
-            stopRoller();
-            return;
-        }
         io.setRollerVoltage(Constants.Intake.ROLLER_FORWARD_VOLTS);
         rollerState = RollerState.RUNNING;
     }
 
     public void reverseRoller() {
-        if (!isSlidePastHome()) {
-            stopRoller();
-            return;
-        }
         io.setRollerVoltage(Constants.Intake.ROLLER_REVERSE_VOLTS);
         rollerState = RollerState.REVERSED;
     }


### PR DESCRIPTION
### Motivation
- Remove the legacy slide-position safety gate that prevented the intake roller from running when the slide was below a configured threshold so roller commands can be issued unconditionally.

### Description
- Deleted the `isSlidePastHome()` checks in `IntakeSubsystem.runRoller()` and `IntakeSubsystem.reverseRoller()` so those methods now always set the configured roller voltages and update `rollerState`.
- Change is limited to `src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java` and was made on branch `chore/remove-roller-slide-safety-check`.

### Testing
- Ran `./gradlew compileJava`, which failed in this environment due to an `Unsupported class file major version 69` during Gradle build-script analysis, so no successful compile was observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2a675dadc832aba563ae06d193000)