### PR TITLE
Change hood fixed position command from onTrue to whileTrue

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -136,7 +136,7 @@ public class RobotContainer {
         // driver.y().whileTrue(intake.fuelPumpCycleDelayed());
        
         // TODO Remove after testing. Set the hood to a fixed position for testing purposes Flywheel RPMS
-        driver.y().onTrue(Commands.runOnce(() -> shooter.setHoodFixed(Constants.Hood.CLOSE_HOOD), shooter));
+        driver.y().whileTrue(shooter.setHoodFixed(Constants.Hood.CLOSE_HOOD));
 
         driver.povLeft().whileTrue(
             FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.CLOSE));


### PR DESCRIPTION
## Summary
Updated the hood fixed position test command to use `whileTrue()` instead of `onTrue()` with `Commands.runOnce()`, simplifying the command binding and changing the execution behavior.

## Key Changes
- Changed `driver.y().onTrue(Commands.runOnce(() -> shooter.setHoodFixed(Constants.Hood.CLOSE_HOOD), shooter))` to `driver.y().whileTrue(shooter.setHoodFixed(Constants.Hood.CLOSE_HOOD))`
- This shifts from a one-time execution on button press to continuous execution while the button is held

## Implementation Details
- The new approach directly calls the `setHoodFixed()` command method instead of wrapping it in `Commands.runOnce()`
- The behavior change from `onTrue()` to `whileTrue()` means the hood will maintain the fixed position for as long as the Y button is pressed, rather than setting it once when pressed
- This is a testing command (marked with TODO for removal after testing)

https://claude.ai/code/session_01R5kQXVuAYEmB6oeMJT6a3Y