### PR TITLE
Fix intake slide positioning by zeroing encoder and clamping targets

### DIFF
--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java
@@ -117,6 +117,7 @@ public class IntakeIOHardware implements IntakeIO {
         PhoenixUtil.applyConfig("Roller Lead",   () -> rollerLead.getConfigurator().apply(RollerConfig.roller()));
         PhoenixUtil.applyConfig("Roller Follow", () -> rollerFollow.getConfigurator().apply(RollerConfig.roller()));
         PhoenixUtil.applyConfig("Slide",         () -> slide.getConfigurator().apply(SlideConfig.slide()));
+        PhoenixUtil.applyConfig("Slide Position Zero", () -> slide.setPosition(Constants.Intake.SLIDE_RETRACTED_POS));
 
         // Cache signal references — slide needs position and velocity for MotionMagic
         // and at-target checks. Roller has no control-critical signals to read.
@@ -126,8 +127,7 @@ public class IntakeIOHardware implements IntakeIO {
         rollerFollow.setControl(
                 new Follower(rollerLead.getDeviceID(), Constants.Intake.RollerConfig.FOLLOWER_ALIGNMENT));
 
-        // Zero slide encoder at startup
-        // slide.setPosition(Constants.Intake.ENCODER_ZERO_POSITION);
+        // Zero slide encoder at startup so MotionMagic setpoints line up with Constants.
     }
 
     @Override
@@ -161,14 +161,20 @@ public class IntakeIOHardware implements IntakeIO {
     // ==== Slide Methods ====
     @Override
     public void setSlidePosition(double position) {
-        slide.setControl(slideRequest.withPosition(position));
+        double clampedPosition = Math.max(
+                Constants.Intake.SlideConfig.REVERSE_SOFT_LIMIT,
+                Math.min(position, Constants.Intake.SLIDE_MAX_POS));
+        slide.setControl(slideRequest.withPosition(clampedPosition));
     }
 
     @Override
     public void setSlidePositionSlow(double position) {
         // This request carries its own cruise/accel limits, so we can tune slow
         // retract independently from the normal Motion Magic profile in config.
-        slide.setControl(slideRequestSlow.withPosition(position));
+        double clampedPosition = Math.max(
+                Constants.Intake.SlideConfig.REVERSE_SOFT_LIMIT,
+                Math.min(position, Constants.Intake.SLIDE_MAX_POS));
+        slide.setControl(slideRequestSlow.withPosition(clampedPosition));
     }
 
     // This was not following the IO pattern and was being called directly by the subsystem


### PR DESCRIPTION
### Motivation
- The intake slide could drive into hard stops because encoder zeroing and out-of-range setpoints were not enforced, causing MotionMagic commands to misalign with the mechanism.
- Startup zeroing is required so `Constants` setpoints (retracted = 0) match the TalonFX encoder reference.
- Command-time clamping prevents accidental requests that would push the slide past software travel limits.

### Description
- Zero the TalonFX slide encoder at startup by calling `slide.setPosition(Constants.Intake.SLIDE_RETRACTED_POS)` immediately after applying the device configs via `PhoenixUtil.applyConfig`.
- Clamp both `setSlidePosition(...)` and `setSlidePositionSlow(...)` to the legal range `Constants.Intake.SlideConfig.REVERSE_SOFT_LIMIT..Constants.Intake.SLIDE_MAX_POS` before sending MotionMagic requests.
- Changes are confined to `src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java` and include a clarifying comment about startup zeroing.

### Testing
- Attempted a local build with `./gradlew build -x test`, but the process failed due to an environment Java/Gradle compatibility error (`Unsupported class file major version 69`) that is unrelated to these code changes.
- No automated tests were completed successfully in this environment because of the Java/Gradle mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d779319090832a935b578d1a7178ef)