### PR TITLE
Align auton pose shot behavior with teleop pose-align flow

### DIFF
--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -48,6 +48,15 @@ public class FuelCommands {
         return MathUtil.inputModulus(targetHeadingDeg - currentHeadingDeg, -180.0, 180.0);
     }
 
+    private static double getDistanceToHubMeters(Pose2d pose, Translation2d hub) {
+        double dx = hub.getX() - pose.getX();
+        double dy = hub.getY() - pose.getY();
+        return MathUtil.clamp(
+                Math.hypot(dx, dy),
+                Constants.Vision.MIN_DISTANCE_M,
+                Constants.Vision.MAX_DISTANCE_M);
+    }
+
     // =========================================================================
     // PRIMARY SHOOT COMMANDS
     // =========================================================================
@@ -469,6 +478,15 @@ public class FuelCommands {
             final SwerveRequest.FieldCentric alignRequest = new SwerveRequest.FieldCentric()
                     .withDriveRequestType(DriveRequestType.OpenLoopVoltage);
 
+            // NT diagnostics for auton analysis (separate table from teleop for easy replay filtering)
+            final NetworkTable visionTable = NetworkTableInstance.getDefault().getTable("AutoPoseAlignShoot");
+            final DoublePublisher ntAngleToHub = visionTable.getDoubleTopic("angleToHub_deg").publish();
+            final DoublePublisher ntCurrentHeading = visionTable.getDoubleTopic("currentHeading_deg").publish();
+            final DoublePublisher ntTargetHeading = visionTable.getDoubleTopic("targetHeading_deg").publish();
+            final DoublePublisher ntHeadingError = visionTable.getDoubleTopic("headingError_deg").publish();
+            final DoublePublisher ntRotRate = visionTable.getDoubleTopic("rotRate_radps").publish();
+            final DoublePublisher ntDistance = visionTable.getDoubleTopic("distanceToHub_m").publish();
+
             return Commands.sequence(
                     // Phase 1: rotate to hub + spin up — both must be ready before feeding
                     Commands.deadline(
@@ -484,16 +502,13 @@ public class FuelCommands {
                                         pose.getRotation().getDegrees());
                                 return Math.abs(headingErrorDeg) <= Constants.Vision.ALIGNMENT_TOLERANCE_DEGREES
                                         && shooter.isReady();
-                                    }).withTimeout(1.0), 
+                                    }).withTimeout(safetyTimeout), 
                             Commands.run(() -> {
                                 Translation2d hub = getHubLocation();
                                 Pose2d pose = drivetrain.getState().Pose;
                                 double dx = hub.getX() - pose.getX();
                                 double dy = hub.getY() - pose.getY();
-                                double distance = MathUtil.clamp(
-                                        Math.hypot(dx, dy),
-                                        Constants.Vision.MIN_DISTANCE_M,
-                                        Constants.Vision.MAX_DISTANCE_M);
+                                double distance = getDistanceToHubMeters(pose, hub);
                                 shooter.updateFromDistance(distance);
                                 if (shooter.getState() != ShooterSubsystem.ShooterState.READY) {
                                     shooter.beginSpinUp();
@@ -503,10 +518,18 @@ public class FuelCommands {
                                 double headingErrorDeg = getHeadingErrorDegrees(
                                         targetHeadingDeg,
                                         pose.getRotation().getDegrees());
-                                double rotRate = MathUtil.clamp(
-                                        headingErrorDeg * Constants.Vision.ROTATIONAL_KP,
-                                        -Constants.Vision.MAX_ALIGNMENT_ROTATION_RAD_PER_SEC,
-                                        Constants.Vision.MAX_ALIGNMENT_ROTATION_RAD_PER_SEC);
+                                double rotRate = Math.abs(headingErrorDeg) <= Constants.Vision.ALIGNMENT_TOLERANCE_DEGREES ? 0.0
+                                        : MathUtil.clamp(
+                                                headingErrorDeg * Constants.Vision.ROTATIONAL_KP,
+                                                -Constants.Vision.MAX_ALIGNMENT_ROTATION_RAD_PER_SEC,
+                                                Constants.Vision.MAX_ALIGNMENT_ROTATION_RAD_PER_SEC);
+
+                                ntAngleToHub.set(angleToHubDeg);
+                                ntCurrentHeading.set(pose.getRotation().getDegrees());
+                                ntTargetHeading.set(targetHeadingDeg);
+                                ntHeadingError.set(headingErrorDeg);
+                                ntRotRate.set(rotRate);
+                                ntDistance.set(distance);
                                 drivetrain.setControl(alignRequest
                                         .withVelocityX(0)
                                         .withVelocityY(0)


### PR DESCRIPTION
### Motivation
- Reduce the mismatch between teleop pose-align shooting and autonomous shot behavior so auton replay/diagnostics match what drivers observe during teleop. 
- Make autonomous shooting easier to diagnose by publishing dedicated NetworkTables entries for auton runs. 

### Description
- Add helper `getDistanceToHubMeters(Pose2d, Translation2d)` to centralize distance clamping and match teleop/auto distance handling. 
- Use the `safetyTimeout` parameter for the auton alignment wait instead of the previous hard-coded `1.0` second timeout. 
- Apply the same deadband behavior used in teleop by zeroing rotational output when within `ALIGNMENT_TOLERANCE_DEGREES` before applying the P-controlled clamp. 
- Publish auton-specific diagnostics to a new NetworkTables table `AutoPoseAlignShoot` with `angleToHub_deg`, `currentHeading_deg`, `targetHeading_deg`, `headingError_deg`, `rotRate_radps`, and `distanceToHub_m`. 

### Testing
- Ran `./gradlew compileJava` in this environment and the build failed with `Unsupported class file major version 69`, which is a JDK/Gradle compatibility issue in the container and not a Java syntax or logic error introduced by this change. 
- No repository-level unit tests were executed in this session due to the environment Java/Gradle mismatch preventing a successful compile.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d830dde374832ab41c711d12ddb3d3)