### PR TITLE
Add fuel compression to autonomous pose-align-and-shoot

### DIFF
--- a/src/main/java/frc/robot/AutoRoutines.java
+++ b/src/main/java/frc/robot/AutoRoutines.java
@@ -45,7 +45,7 @@ public class AutoRoutines {
                 RtTrench_RtMid_RtTrench.atTime("Intake").onTrue(m_intake.intakeFuelTimer(6));
 
                 RtTrench_RtMid_RtTrench.atTime("Shoot")
-                                .onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_drivetrain, 6.0));
+                                .onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, 6.0));
                 RtTrench_RtMid_RtTrench.atTime("FuelPump").onTrue(FuelCommands.Auto.fuelPumpCycleSensor(m_intake, m_indexer));
                 return routine;
         }
@@ -86,7 +86,7 @@ public class AutoRoutines {
                                                 //         /* TODO: Not sure if this will end on it's own or rely on the safety timeout. 
                                                 //         * One possible fix is the CHUTE_SENSOR or literally integrate the fuelPumpCycleSensor() into the autonomous Shooting
                                                 //         */
-                                                //         FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_drivetrain, 6.0),
+                                                //         FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, 6.0),
 
                                                 //         // TODO: Test fuel pump cycle sensor and if it ends on its own, based on sensor. 
                                                 //         FuelCommands.Auto.fuelPumpCycleSensor(m_intake, m_indexer) 
@@ -99,7 +99,7 @@ public class AutoRoutines {
                                                 // RtMid_RtRampShot.cmd(), // 1.6 seconds
                                                 
                                                 // Commands.parallel( 
-                                                //         FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_drivetrain, 6.0), 
+                                                //         FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, 6.0), 
                                                 //         FuelCommands.Auto.fuelPumpCycleSensor(m_intake, m_indexer)
                                                 ) // Approximately 4.0 seconds total for alignment + shooting + pumping
 
@@ -110,7 +110,7 @@ public class AutoRoutines {
                                 );
                 // Routine Events
                 RtTr_RtMid.atTime("Intake").onTrue(m_intake.intakeFuelTimer(6));
-                RtRampAlli_Shot.atTime("Shoot").onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_drivetrain, 6.0));
+                RtRampAlli_Shot.atTime("Shoot").onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, 6.0));
                 // LtTrench_Mid_Trench.atTime("FuelPump").onTrue(FuelCommands.Auto.fuelPumpCycleSensor(m_intake, m_indexer));
 
                 return routine;
@@ -175,7 +175,7 @@ public class AutoRoutines {
                 // Routine Events
                 RtTrench_Mid_Ramp.atTime("Intake").onTrue(m_intake.intakeFuelTimer(6));
                 RtTrench_Mid_Ramp.atTime("Shoot")
-                                .onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_drivetrain, 6.0));
+                                .onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, 6.0));
                 RtTrench_Mid_Ramp.atTime("FuelPump").onTrue(FuelCommands.Auto.fuelPumpCycleSensor(m_intake, m_indexer));
 
                 return routine;
@@ -194,7 +194,7 @@ public class AutoRoutines {
                                 ));
                 // Routine Events
                 LtTrench_Mid_Trench.atTime("Intake").onTrue(m_intake.intakeFuelTimer(8));
-                LtTrench_Mid_Trench.atTime("Shoot").onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_drivetrain, 6.0));
+                LtTrench_Mid_Trench.atTime("Shoot").onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, 6.0));
                 LtTrench_Mid_Trench.atTime("FuelPump").onTrue(FuelCommands.Auto.fuelPumpCycleSensor(m_intake, m_indexer));
 
                 return routine;
@@ -313,7 +313,7 @@ public class AutoRoutines {
                         // Place the "Shoot" event marker at the END of the trajectory segment so the
                         // path finishes before this fires.
                         Experimental.atTime("Shoot")
-                                        .onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_drivetrain,
+                                        .onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain,
                                                         3.0));
 
                         return routine;

--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -463,6 +463,7 @@ public class FuelCommands {
         public static Command poseAlignAndShoot(
                 ShooterSubsystem shooter,
                 IndexerSubsystem indexer,
+                IntakeSubsystem intake,
                 CommandSwerveDrivetrain drivetrain,
                 double safetyTimeout) {
 
@@ -512,13 +513,24 @@ public class FuelCommands {
                                         .withVelocityY(0)
                                         .withRotationalRate(rotRate));
                             }, shooter, drivetrain)),
-                    // Phase 2: feed until chute clears (safetyTimeout is the fallback)
-                    indexer.feedUntilChuteEmpty(safetyTimeout)
+                    // Phase 2: feed until chute clears while compressing fuel once shooter is ready
+                    Commands.deadline(
+                            indexer.feedUntilChuteEmpty(safetyTimeout),
+                            fuelCompressionWhenShooterReady(shooter, intake))
             ).finallyDo(() -> {
                 indexer.indexerStop();
                 indexer.conveyorStop();
                 shooter.setPostShotState();
             }).withName("Auto.PoseAlignAndShoot");
+        }
+
+        private static Command fuelCompressionWhenShooterReady(
+                ShooterSubsystem shooter,
+                IntakeSubsystem intake) {
+            return Commands.sequence(
+                    Commands.waitUntil(shooter::isReady),
+                    intake.fuelCompression())
+                    .withName("FuelCompressionWhenShooterReady");
         }
 
         // =============================================================================


### PR DESCRIPTION
### Motivation
- Ensure intake fuel compression runs automatically during the autonomous pose-and-shoot feed phase once the shooter reports ready.
- Allow existing auto routines to provide the `IntakeSubsystem` so pose-based shoot can coordinate intake and indexer behavior.

### Description
- Changed `FuelCommands.Auto.poseAlignAndShoot(...)` to accept an `IntakeSubsystem` parameter and use it during the feed phase.
- In Phase 2 the indexer feed is now wrapped in `Commands.deadline(...)` to run `indexer.feedUntilChuteEmpty(...)` while also running a helper compression command.
- Added a private helper `fuelCompressionWhenShooterReady(ShooterSubsystem, IntakeSubsystem)` that waits on `shooter::isReady` and then runs `intake.fuelCompression()`. 
- Updated `AutoRoutines` call sites to pass `m_intake` into `FuelCommands.Auto.poseAlignAndShoot(...)` so autos opt into the new behavior.

### Testing
- Ran `./gradlew compileJava` in this environment and the build failed due to a Java/Gradle compatibility error: `Unsupported class file major version 69`.
- No further automated tests completed in this environment due to the compilation issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91bbc926c832abd6a6aa4158a673a)