### PR TITLE
Reduce drivetrain odometry update rate to lower CAN bus load

### DIFF
--- a/src/main/java/frc/robot/generated/TunerConstants.java
+++ b/src/main/java/frc/robot/generated/TunerConstants.java
@@ -202,7 +202,8 @@ public class TunerConstants {
      */
     public static CommandSwerveDrivetrain createDrivetrain() {
         return new CommandSwerveDrivetrain(
-            DrivetrainConstants, FrontLeft, FrontRight, BackLeft, BackRight
+            DrivetrainConstants, 100, // Hz — reduced from default 250 Hz to lower CAN bus utilization
+            FrontLeft, FrontRight, BackLeft, BackRight
         );
     }
 


### PR DESCRIPTION
## Summary
Reduced the CommandSwerveDrivetrain odometry update frequency from the default 250 Hz to 100 Hz to decrease CAN bus utilization.

## Changes
- Added explicit odometry update rate parameter (100 Hz) to `CommandSwerveDrivetrain` constructor in `createDrivetrain()`
- This reduces the frequency of drivetrain state updates sent over the CAN bus, lowering overall network traffic while maintaining adequate odometry precision for robot control

## Implementation Details
The update rate is now explicitly configured rather than relying on the default 250 Hz, providing better control over CAN bus bandwidth allocation and potentially improving system stability under high communication load.

https://claude.ai/code/session_01Acyx18bntxMq74MuKLay2k