### PR TITLE
Reseed field-centric heading when Pigeon2 reconnects

### DIFF
--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -52,6 +52,7 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
     private static final Rotation2d kRedAlliancePerspectiveRotation = Rotation2d.k180deg;
     /* Keep track if we've ever applied the operator perspective before or not */
     private boolean m_hasAppliedOperatorPerspective = false;
+    private boolean m_wasPigeonConnected = true;
 
     /** Swerve request to apply during field-centric path following */
     private final SwerveRequest.ApplyFieldSpeeds m_pathApplyFieldSpeeds = new SwerveRequest.ApplyFieldSpeeds();
@@ -352,6 +353,12 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
                 m_hasAppliedOperatorPerspective = true;
             });
         }
+
+        boolean pigeonConnected = getPigeon2().isConnected().getValue();
+        if (pigeonConnected && !m_wasPigeonConnected) {
+            seedFieldCentric();
+        }
+        m_wasPigeonConnected = pigeonConnected;
     }
 
     private void startSimThread() {


### PR DESCRIPTION
### Motivation
- When the Pigeon2 IMU drops out on the CAN bus the drivetrain can fall back to robot-centric, so the robot should automatically return to field-centric when the IMU reconnects.

### Description
- Add a `m_wasPigeonConnected` flag to `CommandSwerveDrivetrain` and update `periodic()` to read `getPigeon2().isConnected().getValue()` and call `seedFieldCentric()` on a disconnected→connected transition.
- Change contained in `src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java`.

### Testing
- Executed `./gradlew build -x test` which could not complete in this environment due to a Java/Gradle class version mismatch (`Unsupported class file major version 69`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da17c12cc4832ab83dc5492f741360)