### PR TITLE
Refactor RtTrench_Ramp_Double auto routine shooting sequence

### DIFF
--- a/src/main/java/frc/robot/AutoRoutines.java
+++ b/src/main/java/frc/robot/AutoRoutines.java
@@ -52,11 +52,14 @@ public class AutoRoutines {
                                 Commands.sequence(
                                                 RtTr_RtMid.resetOdometry(),
 
-                                                RtTr_RtMid.cmd(),  
+                                                RtTr_RtMid.cmd(),
 
                                                 RtRampMid_RtRampAlli.cmd(),
 
                                                 RtRampAlli_Shot.cmd(),
+
+                                                // Shoot 1st time
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, 5.0),
 
                                                 // Back to trench
                                                 RtShot_Trench.cmd(),
@@ -65,19 +68,19 @@ public class AutoRoutines {
                                                 RtTr_CurlSweep.cmd(),
 
                                                 // Come across 2nd time
-                                                RtRampMid_RtRampAlli2.cmd(), 
+                                                RtRampMid_RtRampAlli2.cmd(),
 
                                                 // Shoot 2nd time
-                                                RtRampAlli_Shot2.cmd()
+                                                RtRampAlli_Shot2.cmd(),
+
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, 5.0)
 
                                                 )
 
                                 );
                 // Routine Events
                 RtTr_RtMid.atTime("Intake").onTrue(m_intake.intakeFuelTimer(6));
-                RtRampAlli_Shot.atTime("Shoot").onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, 5.0));
                 RtTr_CurlSweep.atTime("Intake").onTrue(m_intake.intakeFuelTimer(6));
-                RtRampAlli_Shot2.atTime("Shoot").onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, 5.0));
                 // LtTrench_Mid_Trench.atTime("FuelPump").onTrue(FuelCommands.Auto.fuelPumpCycleSensor(m_intake, m_indexer));
 
                 return routine;


### PR DESCRIPTION
## Summary
Refactored the `RtTrench_Ramp_Double` auto routine to explicitly sequence shooting commands within the main command sequence rather than triggering them via event listeners.

## Key Changes
- Moved `poseAlignAndShoot` commands from event-based triggers into the main sequential command flow
  - Added explicit `poseAlignAndShoot` call after first ramp alignment (`RtRampAlli_Shot`)
  - Added explicit `poseAlignAndShoot` call after second ramp alignment (`RtRampAlli_Shot2`)
- Removed event listener registrations that were previously triggering the shooting commands:
  - Removed `RtRampAlli_Shot.atTime("Shoot")` event listener
  - Removed `RtRampAlli_Shot2.atTime("Shoot")` event listener
- Fixed trailing whitespace inconsistencies in the command sequence

## Implementation Details
This change improves command sequencing clarity by making the shooting actions explicit steps in the routine rather than implicit event-driven actions. The shooting commands now execute as part of the deterministic sequence, ensuring more predictable timing and easier debugging of the auto routine.

https://claude.ai/code/session_013XqW5K5fBDo3iUxo8R7hMr