### PR TITLE
Add individual motor direction tests for shooter and indexer

### DIFF
--- a/src/main/java/frc/robot/commands/MotorDirectionTests.java
+++ b/src/main/java/frc/robot/commands/MotorDirectionTests.java
@@ -1,0 +1,90 @@
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Commands;
+import frc.robot.subsystems.indexer.IndexerSubsystem;
+import frc.robot.subsystems.shooter.ShooterSubsystem;
+
+/**
+ * Individual motor direction tests for verifying each motor spins the correct
+ * way BEFORE locking them into a lead-follow relationship during a match.
+ *
+ * Each test runs a single motor at a safe voltage while held (startEnd pattern).
+ * Release the button and the motor stops. Follower tests automatically re-lock
+ * the follower on release.
+ *
+ * Usage in RobotContainer (bind to operator buttons):
+ * <pre>
+ *   operatorController.a().whileTrue(MotorDirectionTests.flywheelLeader(shooter));
+ *   operatorController.b().whileTrue(MotorDirectionTests.flywheelFollower(shooter));
+ *   operatorController.x().whileTrue(MotorDirectionTests.kickerLeader(indexer));
+ *   operatorController.y().whileTrue(MotorDirectionTests.kickerFollower(indexer));
+ * </pre>
+ *
+ * Or run testAllSequence() to cycle through each motor automatically with a
+ * hold time between each.
+ */
+public final class MotorDirectionTests {
+
+    /** Safe test voltage — enough to see direction, not enough to launch anything. */
+    private static final double TEST_VOLTS = 3.0;
+
+    /** How long each motor runs during the automatic sequence. */
+    private static final double HOLD_SECONDS = 2.0;
+
+    /** Pause between motors so the operator can observe. */
+    private static final double PAUSE_SECONDS = 1.0;
+
+    private MotorDirectionTests() {}
+
+    // =====================================================================
+    // Individual hold-to-run tests (bind to buttons)
+    // =====================================================================
+
+    /** Hold to spin flywheel leader only. Follower mirrors since link is intact. */
+    public static Command flywheelLeader(ShooterSubsystem shooter) {
+        return shooter.testFlywheelLeader(TEST_VOLTS);
+    }
+
+    /** Hold to spin flywheel follower only. Leader stays still. Re-locks on release. */
+    public static Command flywheelFollower(ShooterSubsystem shooter) {
+        return shooter.testFlywheelFollower(TEST_VOLTS);
+    }
+
+    /** Hold to spin kicker leader only. Follower mirrors since link is intact. */
+    public static Command kickerLeader(IndexerSubsystem indexer) {
+        return indexer.testKickerLeader(TEST_VOLTS);
+    }
+
+    /** Hold to spin kicker follower only. Leader stays still. Re-locks on release. */
+    public static Command kickerFollower(IndexerSubsystem indexer) {
+        return indexer.testKickerFollower(TEST_VOLTS);
+    }
+
+    // =====================================================================
+    // Automatic sequence (runs all four, one at a time)
+    // =====================================================================
+
+    /**
+     * Runs each motor individually for HOLD_SECONDS, pausing between each.
+     * Order: flywheel leader → flywheel follower → kicker leader → kicker follower.
+     * Bind to a dashboard button or a spare controller button for pit testing.
+     */
+    public static Command testAllSequence(ShooterSubsystem shooter, IndexerSubsystem indexer) {
+        return Commands.sequence(
+            timedTest(shooter.testFlywheelLeader(TEST_VOLTS), "Flywheel Leader"),
+            Commands.waitSeconds(PAUSE_SECONDS),
+            timedTest(shooter.testFlywheelFollower(TEST_VOLTS), "Flywheel Follower"),
+            Commands.waitSeconds(PAUSE_SECONDS),
+            timedTest(indexer.testKickerLeader(TEST_VOLTS), "Kicker Leader"),
+            Commands.waitSeconds(PAUSE_SECONDS),
+            timedTest(indexer.testKickerFollower(TEST_VOLTS), "Kicker Follower")
+        ).withName("MotorDirectionTest: All");
+    }
+
+    private static Command timedTest(Command testCommand, String label) {
+        return testCommand
+            .withTimeout(HOLD_SECONDS)
+            .withName("MotorDirectionTest: " + label);
+    }
+}

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerIO.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerIO.java
@@ -80,4 +80,32 @@ public interface IndexerIO {
 
     /** Stops both motors. */
     default void stop() {}
+
+    // ===== Individual Motor Test Methods ======================================
+    // These bypass the follower relationship so each kicker motor can be verified
+    // independently. Calling setKickerFollowerVolts() overrides the follower
+    // control request — call reestablishKickerFollower() when done to re-lock it.
+
+    /**
+     * Runs the kicker LEADER motor only at a fixed voltage (open-loop).
+     * The follower will still mirror this if it is in follower mode.
+     *
+     * @param volts Voltage to apply
+     */
+    default void setKickerLeaderVolts(double volts) {}
+
+    /**
+     * Runs the kicker FOLLOWER motor independently at a fixed voltage.
+     * This BREAKS the follower link — the follower will no longer mirror the leader
+     * until {@link #reestablishKickerFollower()} is called.
+     *
+     * @param volts Voltage to apply
+     */
+    default void setKickerFollowerVolts(double volts) {}
+
+    /**
+     * Re-locks the kicker follower to the leader after individual testing.
+     * Must be called after using setKickerFollowerVolts() to restore normal operation.
+     */
+    default void reestablishKickerFollower() {}
 }

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerIOHardware.java
@@ -173,4 +173,22 @@ public class IndexerIOHardware implements IndexerIO {
         // Stop lead only — follower mirrors the leader's NeutralOut automatically.
         kickerMotorLead.stopMotor();
     }
+
+    // == Individual Motor Test Methods =========================================
+
+    @Override
+    public void setKickerLeaderVolts(double volts) {
+        kickerMotorLead.setControl(kickerLeadVoltageRequest.withOutput(volts));
+    }
+
+    @Override
+    public void setKickerFollowerVolts(double volts) {
+        // Sending a direct control request to the follower overrides its Follower link.
+        kickerMotorFollow.setControl(new VoltageOut(volts).withEnableFOC(false));
+    }
+
+    @Override
+    public void reestablishKickerFollower() {
+        kickerMotorFollow.setControl(kickerFollowerRequest);
+    }
 }

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
@@ -393,6 +393,41 @@ public class IndexerSubsystem extends SubsystemBase {
                 .withName("ConveyorReverseThenForwardHold");
     }
 
+    // =====================================================================
+    // Individual Motor Test Commands
+    // =====================================================================
+
+    /**
+     * Runs ONLY the kicker leader motor at a fixed voltage while held.
+     * The follower will still mirror the leader (this does NOT break the follower link).
+     */
+    public Command testKickerLeader(double volts) {
+        return Commands.startEnd(
+            () -> io.setKickerLeaderVolts(volts),
+            () -> io.stop(),
+            this
+        ).withName("Test: Kicker Leader @ " + volts + "V");
+    }
+
+    /**
+     * Runs ONLY the kicker follower motor independently at a fixed voltage while held.
+     * This BREAKS the follower link for the duration of the test.
+     * The leader will NOT spin. Re-locks the follower on release.
+     */
+    public Command testKickerFollower(double volts) {
+        return Commands.startEnd(
+            () -> {
+                io.stop();                        // ensure leader is stopped
+                io.setKickerFollowerVolts(volts);  // override follower with direct voltage
+            },
+            () -> {
+                io.stop();
+                io.reestablishKickerFollower();    // re-lock follower to leader
+            },
+            this
+        ).withName("Test: Kicker Follower @ " + volts + "V");
+    }
+
     /** Test profile: 4 V for 1 s, then 2 V for 2 s, repeated until interrupted. */
     public Command conveyorPulseProfile() {
         return Commands.repeatingSequence(

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIO.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIO.java
@@ -127,4 +127,32 @@ public interface ShooterIO {
      * Stops all shooter motors (flywheels, hood).
      */
     default void stop() {}
+
+    // ===== Individual Motor Test Methods ======================================
+    // These bypass the follower relationship so each motor can be verified
+    // independently. Calling setFlywheelFollowerVolts() overrides the follower
+    // control request — call reestablishFlywheelFollower() when done to re-lock it.
+
+    /**
+     * Runs the flywheel LEADER motor only at a fixed voltage (open-loop).
+     * The follower will still mirror this if it is in follower mode.
+     *
+     * @param volts Voltage to apply
+     */
+    default void setFlywheelLeaderVolts(double volts) {}
+
+    /**
+     * Runs the flywheel FOLLOWER motor independently at a fixed voltage.
+     * This BREAKS the follower link — the follower will no longer mirror the leader
+     * until {@link #reestablishFlywheelFollower()} is called.
+     *
+     * @param volts Voltage to apply
+     */
+    default void setFlywheelFollowerVolts(double volts) {}
+
+    /**
+     * Re-locks the flywheel follower to the leader after individual testing.
+     * Must be called after using setFlywheelFollowerVolts() to restore normal operation.
+     */
+    default void reestablishFlywheelFollower() {}
 }

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOHardware.java
@@ -7,6 +7,7 @@ import com.ctre.phoenix6.configs.TalonFXSConfiguration;
 import com.ctre.phoenix6.controls.Follower;
 import com.ctre.phoenix6.controls.MotionMagicVelocityVoltage;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.hardware.TalonFXS;
 
@@ -121,6 +122,7 @@ public class ShooterIOHardware implements ShooterIO {
   // == Control Requests =====================================================
  private final MotionMagicVelocityVoltage flywheelVelocityRequest = new MotionMagicVelocityVoltage(0.0).withEnableFOC(false);
 private final MotionMagicVoltage hoodPositionRequest = new MotionMagicVoltage(0.0).withEnableFOC(false);
+  private final VoltageOut testVoltageRequest = new VoltageOut(0.0).withEnableFOC(false);
 
   // Flywheel follower was mechanically flipped again, so it must oppose the
   // leader's shaft rotation while still producing the same flywheel surface
@@ -237,6 +239,24 @@ private final MotionMagicVoltage hoodPositionRequest = new MotionMagicVoltage(0.
     // Stop leader only - follower mirrors to neutral automatically (see stopFlywheels).
     flywheelLeader.stopMotor();
     hoodMotor.stopMotor();
+  }
+
+  // == Individual Motor Test Methods =========================================
+
+  @Override
+  public void setFlywheelLeaderVolts(double volts) {
+    flywheelLeader.setControl(testVoltageRequest.withOutput(volts));
+  }
+
+  @Override
+  public void setFlywheelFollowerVolts(double volts) {
+    // Sending a direct control request to the follower overrides its Follower link.
+    flywheelFollower.setControl(testVoltageRequest.withOutput(volts));
+  }
+
+  @Override
+  public void reestablishFlywheelFollower() {
+    flywheelFollower.setControl(flywheelFollowerRequest);
   }
 
   // == Unit Conversions ===================================================

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -588,6 +588,42 @@ public class ShooterSubsystem extends SubsystemBase {
      *
      * @param rpm Target flywheel RPM
      */
+    // =====================================================================
+    // Individual Motor Test Commands
+    // =====================================================================
+
+    /**
+     * Runs ONLY the flywheel leader motor at a fixed voltage while held.
+     * The follower will still mirror the leader (this does NOT break the follower link).
+     * Use this first to verify the leader spins the correct direction.
+     */
+    public Command testFlywheelLeader(double volts) {
+        return Commands.startEnd(
+            () -> io.setFlywheelLeaderVolts(volts),
+            () -> io.stopFlywheels(),
+            this
+        ).withName("Test: Flywheel Leader @ " + volts + "V");
+    }
+
+    /**
+     * Runs ONLY the flywheel follower motor independently at a fixed voltage while held.
+     * This BREAKS the follower link for the duration of the test.
+     * The leader will NOT spin. Re-locks the follower on release.
+     */
+    public Command testFlywheelFollower(double volts) {
+        return Commands.startEnd(
+            () -> {
+                io.stopFlywheels();               // ensure leader is stopped
+                io.setFlywheelFollowerVolts(volts); // override follower with direct voltage
+            },
+            () -> {
+                io.stopFlywheels();
+                io.reestablishFlywheelFollower();  // re-lock follower to leader
+            },
+            this
+        ).withName("Test: Flywheel Follower @ " + volts + "V");
+    }
+
     public Command tuneFlywheelCommand(double rpm) {
         return Commands.startEnd(
             () -> {


### PR DESCRIPTION
## Summary
Adds a comprehensive motor direction testing framework that allows operators to verify each motor (flywheel leader/follower, kicker leader/follower) spins in the correct direction before locking them into lead-follow relationships during a match.

## Key Changes

- **New `MotorDirectionTests` command class**: Provides both individual hold-to-run tests (bindable to operator buttons) and an automatic `testAllSequence()` that cycles through all four motors with configurable hold and pause times
  - Safe test voltage of 3.0V to verify direction without launching projectiles
  - Includes detailed usage examples for RobotContainer button binding

- **ShooterSubsystem**: Added two new test commands
  - `testFlywheelLeader()`: Runs leader only; follower mirrors since link remains intact
  - `testFlywheelFollower()`: Runs follower independently by breaking the follower link; re-locks on release

- **IndexerSubsystem**: Added two new test commands
  - `testKickerLeader()`: Runs leader only; follower mirrors since link remains intact
  - `testKickerFollower()`: Runs follower independently by breaking the follower link; re-locks on release

- **IO Interface Updates**: Added three new default methods to both `ShooterIO` and `IndexerIO`
  - `setFlywheelLeaderVolts()` / `setKickerLeaderVolts()`: Direct voltage control for leader motors
  - `setFlywheelFollowerVolts()` / `setKickerFollowerVolts()`: Direct voltage control that overrides follower link
  - `reestablishFlywheelFollower()` / `reestablishKickerFollower()`: Re-locks follower to leader after testing

- **Hardware Implementation**: Updated `ShooterIOHardware` and `IndexerIOHardware` to implement the new test methods using `VoltageOut` control requests

## Implementation Details

- Tests use the `startEnd` command pattern: voltage applied on start, motors stopped and follower re-locked on end
- Follower tests explicitly break the follower link by sending direct control requests, then restore it on release
- All test commands are named for easy identification in logs and dashboards
- Automatic sequence includes 1-second pauses between motors for operator observation

https://claude.ai/code/session_01GBWzEkeauGUQGA8Wp5qDn2