### PR TITLE
claude/review-auto-routine-velocity-RaXoH

### DIFF
--- a/src/main/deploy/choreo/RtTrench_HubSweep.traj
+++ b/src/main/deploy/choreo/RtTrench_HubSweep.traj
@@ -10,7 +10,8 @@
     {"from":"first", "to":null, "data":{"type":"StopPoint", "props":{}}, "enabled":true},
     {"from":"last", "to":null, "data":{"type":"StopPoint", "props":{}}, "enabled":true},
     {"from":"first", "to":"last", "data":{"type":"KeepInRectangle", "props":{"x":0.0, "y":0.0, "w":16.541, "h":8.0692}}, "enabled":true},
-    {"from":"first", "to":"last", "data":{"type":"MaxVelocity", "props":{"max":2.2}}, "enabled":true}],
+    {"from":"first", "to":1, "data":{"type":"MaxVelocity", "props":{"max":2.2}}, "enabled":true},
+    {"from":1, "to":"last", "data":{"type":"MaxVelocity", "props":{"max":1.5}}, "enabled":true}],
   "targetDt":0.05
  },
  "params":{
@@ -22,7 +23,8 @@
     {"from":"first", "to":null, "data":{"type":"StopPoint", "props":{}}, "enabled":true},
     {"from":"last", "to":null, "data":{"type":"StopPoint", "props":{}}, "enabled":true},
     {"from":"first", "to":"last", "data":{"type":"KeepInRectangle", "props":{"x":{"exp":"0 m", "val":0.0}, "y":{"exp":"0 m", "val":0.0}, "w":{"exp":"16.541 m", "val":16.541}, "h":{"exp":"8.0692 m", "val":8.0692}}}, "enabled":true},
-    {"from":"first", "to":"last", "data":{"type":"MaxVelocity", "props":{"max":{"exp":"MediumVel", "val":2.2}}}, "enabled":true}],
+    {"from":"first", "to":1, "data":{"type":"MaxVelocity", "props":{"max":{"exp":"MediumVel", "val":2.2}}}, "enabled":true},
+    {"from":1, "to":"last", "data":{"type":"MaxVelocity", "props":{"max":{"exp":"IntakeVel", "val":1.5}}}, "enabled":true}],
   "targetDt":{
    "exp":"0.05 s",
    "val":0.05

--- a/src/main/java/frc/robot/AutoRoutines.java
+++ b/src/main/java/frc/robot/AutoRoutines.java
@@ -217,7 +217,13 @@ public class AutoRoutines {
 
                                                 RtHub_Purge.cmd(),
 
-                                                FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout) // purge command; adjust timeout as needed
+                                                // Purge while holding the drivetrain at zero velocity.
+                                                // purgeFuel only requires intake + indexer, so without the
+                                                // deadline the drivetrain has no command owner and the robot
+                                                // drifts from residual trajectory momentum.
+                                                Commands.deadline(
+                                                                FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout),
+                                                                m_drivetrain.stop())
 
                                 ));
 
@@ -267,7 +273,9 @@ public class AutoRoutines {
 
                                                 RtHub_Purge.cmd(),
 
-                                                FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout) // purge command; adjust timeout as needed
+                                                Commands.deadline(
+                                                                FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout),
+                                                                m_drivetrain.stop())
 
                                 ));
 


### PR DESCRIPTION
- RtTrench_HubSweep.traj: split MaxVelocity into two segment constraints:
  MediumVel (first→WP1) for the drive-to-position phase, IntakeVel (WP1→last)
  for the hub sweep where intake is active. Previously the entire path ran at
  MediumVel (2.2 m/s), leaving the sweep section unthrottled.
  NOTE: re-solve in Choreo to regenerate trajectory samples from new constraints.

- AutoRoutines.java (Purge + AngryPurge): wrap purgeFuel inside
  Commands.deadline(..., m_drivetrain.stop()). purgeFuel only requires
  intake + indexer, so the drivetrain had no command owner after RtHub_Purge
  completed — the robot drifted from residual momentum and the heading set by
  the trajectory was lost. The deadline holds the robot at zero velocity for
  the full purge duration.

https://claude.ai/code/session_017x16ezuPETfR4gU22sTGxQ