### PR TITLE
claude/review-auto-routine-10nZZ

### DIFF
--- a/src/main/java/frc/robot/AutoRoutines.java
+++ b/src/main/java/frc/robot/AutoRoutines.java
@@ -233,7 +233,10 @@ public class AutoRoutines {
                                                                 m_intake.intakeFuelTimer(intakeTimeout, intakeDelay)),
                                                 RtHub_Purge.cmd(),
 
-                                                FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout) // purge command; adjust timeout as needed
+                                                Commands.deadline(
+                                                        FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout),
+                                                        m_drivetrain.stop()
+                                                )
 
                                 ));
 
@@ -283,7 +286,10 @@ public class AutoRoutines {
 
                                                 RtHub_Purge.cmd(),
 
-                                                FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout) // purge command; adjust timeout as needed
+                                                Commands.deadline(
+                                                        FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout),
+                                                        m_drivetrain.stop()
+                                                )
 
                                 ));
 
@@ -484,8 +490,11 @@ public class AutoRoutines {
                                                                 LtTrench_HubSweep.cmd(),
                                                                 m_intake.intakeFuelTimer(intakeTimeout, intakeDelay)),
                                                 LtHub_Purge.cmd(),
-                                                
-                                                FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout) // purge command; adjust timeout as needed
+
+                                                Commands.deadline(
+                                                        FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout),
+                                                        m_drivetrain.stop()
+                                                )
                                 ));
 
                 return routine;
@@ -536,8 +545,11 @@ public class AutoRoutines {
                                                                 LtTrench_HubSweep.cmd(),
                                                                 m_intake.intakeFuelTimer(intakeTimeout, intakeDelay)),
                                                 LtHub_Purge.cmd(),
-                                                
-                                                FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout) // purge command; adjust timeout as needed
+
+                                                Commands.deadline(
+                                                        FuelCommands.purgeFuel(m_intake, m_indexer).withTimeout(purgeTimeout),
+                                                        m_drivetrain.stop()
+                                                )
                                 ));
 
                 return routine;


### PR DESCRIPTION
purgeFuel only requires intake and indexer, so after the Purge
trajectory finished the drivetrain was released and the teleop
default command took over, causing the robot to drift. Wrap each
purgeFuel call in Commands.deadline(..., m_drivetrain.stop()) so
the drivetrain stays commanded to zero velocity for the full purge
duration.

Affects: RtTrench_Ramp_Sweep_Purge, RtTrench_Ramp_Sweep_AngryPurge,
         LtTrench_Ramp_Sweep_Purge, LtTrench_Ramp_Sweep_AngryPurge

https://claude.ai/code/session_01TYtUwDrjwmoGzEwPjZVraH