### PR TITLE
Switch conveyor forward to closed-loop velocity control

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -212,9 +212,13 @@ public final class Constants {
      * Conveyor voltage setpoints for feeding fuel to the shooter.
      */
     
+    // Conveyor forward velocity target: 2440 RPM observed at 5V → 2440/60 ≈ 40.67 RPS
+    public static final double CONVEYOR_FORWARD_RPS = 2440.0 / 60.0;
+
+    // Fallback voltage (VoltageOut) — kept for reference, not used in normal operation
     // TODO Consider increasing conveyor voltage
     // Increased to 4 -> 5 before Q4
-    public static final double CONVEYOR_FORWARD_VOLTAGE = 5;
+    // public static final double CONVEYOR_FORWARD_VOLTAGE = 5;
 
     public static final double CONVEYOR_REVERSE_VOLTAGE = -7;
 
@@ -275,6 +279,12 @@ public final class Constants {
       public static final double STATOR_CURRENT_LIMIT = 40.0;
       public static final double PEAK_FORWARD_VOLTAGE = 12.0;
       public static final double PEAK_REVERSE_VOLTAGE = -12.0;
+
+      /* VelocityVoltage PID — Slot 0 (conveyor forward).
+       * kV derived from observed 5V ≈ 2440 RPM (40.67 RPS): 5 / 40.67 ≈ 0.123 V/RPS.
+       * kP is a conservative starting point; tune with Phoenix Tuner X under load. */
+      public static final double SLOT0_KV = 0.123; // V per RPS feedforward
+      public static final double SLOT0_KP = 0.1;   // V per RPS error
     }
 
     public static final class KickerLeaderConfig {

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerIO.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerIO.java
@@ -65,7 +65,16 @@ public interface IndexerIO {
     default void updateInputs(IndexerIOInputs inputs) {}
 
     /**
-     * Sets the conveyor motor output voltage.
+     * Sets the conveyor motor to a closed-loop velocity target (VelocityVoltage, Slot 0).
+     * Use for normal forward operation.
+     *
+     * @param rps Target velocity in rotations per second (positive = toward indexer)
+     */
+    default void setConveyorVelocity(double rps) {}
+
+    /**
+     * Sets the conveyor motor output voltage (VoltageOut).
+     * Used for reverse and popper; kept as fallback for forward if needed.
      *
      * @param volts Positive = toward indexer, negative = reverse
      */

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerIOHardware.java
@@ -6,6 +6,7 @@ import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.CANrangeConfiguration;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.Follower;
+import com.ctre.phoenix6.controls.VelocityVoltage;
 import com.ctre.phoenix6.controls.VoltageOut;
 import com.ctre.phoenix6.hardware.CANrange;
 import com.ctre.phoenix6.hardware.TalonFX;
@@ -49,6 +50,10 @@ public class IndexerIOHardware implements IndexerIO {
 
         config.Voltage.PeakForwardVoltage = Constants.Indexer.ConveyorConfig.PEAK_FORWARD_VOLTAGE;
         config.Voltage.PeakReverseVoltage = Constants.Indexer.ConveyorConfig.PEAK_REVERSE_VOLTAGE;
+
+        // Slot 0 — used by VelocityVoltage for conveyor forward
+        config.Slot0.kV = Constants.Indexer.ConveyorConfig.SLOT0_KV;
+        config.Slot0.kP = Constants.Indexer.ConveyorConfig.SLOT0_KP;
 
         return config;
     }
@@ -105,6 +110,9 @@ public class IndexerIOHardware implements IndexerIO {
     private final CANrange chuteToF;
 
     // == Control Requests ==========================================================
+    // Conveyor forward uses VelocityVoltage (Slot 0). Reverse/popper still use VoltageOut.
+    // Fallback: private final VoltageOut conveyorVoltageRequest = new VoltageOut(0.0).withEnableFOC(false);
+    private final VelocityVoltage conveyorVelocityRequest = new VelocityVoltage(0.0).withSlot(0).withEnableFOC(false);
     private final VoltageOut conveyorVoltageRequest = new VoltageOut(0.0).withEnableFOC(false);
     private final VoltageOut kickerLeadVoltageRequest  = new VoltageOut(0.0).withEnableFOC(false);
     private final Follower kickerFollowerRequest =
@@ -172,6 +180,11 @@ public class IndexerIOHardware implements IndexerIO {
         inputs.kickerFollowCurrentAmps = kickerFollowCurrent.getValueAsDouble();
         inputs.chuteDistanceMeters = chuteDistance.getValueAsDouble();
         inputs.chuteDetected       = chuteIsDetected.getValue();
+    }
+
+    @Override
+    public void setConveyorVelocity(double rps) {
+        conveyorMotor.setControl(conveyorVelocityRequest.withVelocity(rps));
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
@@ -124,7 +124,7 @@ public class IndexerSubsystem extends SubsystemBase {
     // Motor Control
     // =====================================================================
     public void conveyorForward() {
-        io.setConveyorMotor(Constants.Indexer.CONVEYOR_FORWARD_VOLTAGE);
+        io.setConveyorVelocity(Constants.Indexer.CONVEYOR_FORWARD_RPS);
     }
 
     public void reverseConveyor() {


### PR DESCRIPTION
## Summary
Migrated the conveyor forward control from open-loop voltage control to closed-loop velocity control using Phoenix 6's `VelocityVoltage` with PID tuning. This improves consistency and load handling for the conveyor motor.

## Key Changes
- **Added velocity control method**: Introduced `setConveyorVelocity(double rps)` in `IndexerIO` interface and implemented it in `IndexerIOHardware` using `VelocityVoltage` with Slot 0
- **PID configuration**: Added Slot 0 PID gains to `ConveyorConfig`:
  - `SLOT0_KV = 0.123` V/RPS (feedforward derived from observed 5V ≈ 2440 RPM)
  - `SLOT0_KP = 0.1` V/RPS (conservative proportional gain for tuning)
- **Constants update**: 
  - Replaced `CONVEYOR_FORWARD_VOLTAGE` with `CONVEYOR_FORWARD_RPS = 40.67 RPS` (2440 RPM / 60)
  - Commented out old voltage constant for reference
- **Subsystem integration**: Updated `conveyorForward()` to call `setConveyorVelocity()` instead of `setConveyorMotor()`
- **Preserved fallback**: Kept `setConveyorMotor()` for reverse and popper operations using `VoltageOut`

## Implementation Details
- Velocity control uses closed-loop feedback to maintain target speed regardless of load variations
- kV feedforward value calculated from empirical observation: 5V produces ~2440 RPM
- kP gain is intentionally conservative and should be tuned under load using Phoenix Tuner X
- Reverse and popper operations continue using voltage control as they don't require velocity regulation

https://claude.ai/code/session_01UeD1q9kk8nwsMd6TGWt2pf