### PR TITLE
Scale indexer feed speed with shooter target RPM

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -215,6 +215,12 @@ public final class Constants {
     // TODO Consider increasing conveyor voltage
     // Increased to 4 -> 5 before Q4
     public static final double CONVEYOR_FORWARD_VOLTAGE = 5;
+    /**
+     * At 2400 flywheel motor RPM, desired conveyor speed is 2700 RPM.
+     * This is 112.5% of flywheel target speed.
+     */
+    public static final double CONVEYOR_TARGET_PERCENT_OF_FLYWHEEL = 2700.0 / 2400.0;
+    public static final double CONVEYOR_REFERENCE_FLYWHEEL_MOTOR_RPM = 2400.0;
 
     public static final double CONVEYOR_REVERSE_VOLTAGE = -7;
 
@@ -233,6 +239,12 @@ public final class Constants {
 
     // TODO Consider increasing kicker voltage
     public static final double KICKER_FORWARD_VOLTAGE = 5.0;
+    /**
+     * At 2400 flywheel motor RPM, desired kicker speed is 2700 RPM.
+     * This is 112.5% of flywheel target speed.
+     */
+    public static final double KICKER_TARGET_PERCENT_OF_FLYWHEEL = 2700.0 / 2400.0;
+    public static final double KICKER_REFERENCE_FLYWHEEL_MOTOR_RPM = 2400.0;
     
     // Reverse voltage for ejecting fuel and clearing jams. 
     public static final double KICKER_REVERSE_VOLTAGE = -6.0;

--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -143,8 +143,7 @@ public class FuelCommands {
                 }, shooter),
                 Commands.waitUntil(shooter::isReady).withTimeout(2.0), 
                 Commands.run(() -> {
-                    indexer.conveyorForward();
-                    indexer.kickerForward();
+                    indexer.feedForwardScaledToFlywheel(shooter.getTargetVelocityRPM());
                 }, indexer))
                 .finallyDo(() -> {
                     indexer.indexerStop();
@@ -274,8 +273,7 @@ public class FuelCommands {
                 }, shooter),
                 Commands.waitUntil(shooter::isPassReady).withTimeout(3.0),
                 Commands.run(() -> {
-                    indexer.conveyorForward();
-                    indexer.kickerForward();
+                    indexer.feedForwardScaledToFlywheel(shooter.getTargetVelocityRPM());
                 }, indexer))
                 .finallyDo(() -> {
                     indexer.indexerStop();
@@ -513,8 +511,7 @@ public class FuelCommands {
 
             // 4. Feed: aligned (PID at setpoint) AND flywheel/hood settled
             if (shooter.isReady() && headingPID.atSetpoint()) {
-                indexer.conveyorForward();
-                indexer.kickerForward();
+                indexer.feedForwardScaledToFlywheel(shooter.getTargetVelocityRPM());
             } else {
                 indexer.indexerStop();
                 indexer.conveyorStop();

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
@@ -4,6 +4,7 @@ import edu.wpi.first.networktables.BooleanPublisher;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.StringPublisher;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
@@ -141,6 +142,39 @@ public class IndexerSubsystem extends SubsystemBase {
 
     public void kickerForward() {
         io.setKickerMotorVolts(Constants.Indexer.KICKER_FORWARD_VOLTAGE);
+    }
+
+    /**
+     * Runs conveyor and kicker as a percent of the shooter flywheel target.
+     * Percent is anchored so 2400 flywheel motor RPM maps to 2700 indexer RPM
+     * intent (112.5%).
+     *
+     * Since indexer motors are currently open-loop voltage controlled, this scales
+     * the known-good feed voltages proportionally to flywheel target RPM.
+     *
+     * @param targetFlywheelMotorRPM shooter target in motor RPM
+     */
+    public void feedForwardScaledToFlywheel(double targetFlywheelMotorRPM) {
+        double desiredConveyorRpm = Math.abs(targetFlywheelMotorRPM) * Constants.Indexer.CONVEYOR_TARGET_PERCENT_OF_FLYWHEEL;
+        double conveyorReferenceRpm = Constants.Indexer.CONVEYOR_REFERENCE_FLYWHEEL_MOTOR_RPM
+                * Constants.Indexer.CONVEYOR_TARGET_PERCENT_OF_FLYWHEEL;
+        double flywheelRatio = desiredConveyorRpm / conveyorReferenceRpm;
+        double conveyorVolts = MathUtil.clamp(
+                Constants.Indexer.CONVEYOR_FORWARD_VOLTAGE * flywheelRatio,
+                0.0,
+                Constants.Indexer.ConveyorConfig.PEAK_FORWARD_VOLTAGE);
+
+        double desiredKickerRpm = Math.abs(targetFlywheelMotorRPM) * Constants.Indexer.KICKER_TARGET_PERCENT_OF_FLYWHEEL;
+        double kickerReferenceRpm = Constants.Indexer.KICKER_REFERENCE_FLYWHEEL_MOTOR_RPM
+                * Constants.Indexer.KICKER_TARGET_PERCENT_OF_FLYWHEEL;
+        flywheelRatio = desiredKickerRpm / kickerReferenceRpm;
+        double kickerVolts = MathUtil.clamp(
+                Constants.Indexer.KICKER_FORWARD_VOLTAGE * flywheelRatio,
+                0.0,
+                Constants.Indexer.KickerLeaderConfig.PEAK_FORWARD_VOLTAGE);
+
+        io.setConveyorMotor(conveyorVolts);
+        io.setKickerMotorVolts(kickerVolts);
     }
 
     public void indexerReverse() {


### PR DESCRIPTION
### Motivation
- Make the conveyor and kicker follow the shooter target velocity so feeding scales with shot speed, with the requested anchor that at 2400 flywheel motor RPM the kicker and conveyor should be 2700 RPM (112.5%).
- Use the shooter's target motor-RPM value (not a wheel speed mismatch) so the indexer scaling is consistent with existing shooter code paths.

### Description
- Added constants in `Constants.java` to document the 2400→2700 mapping and expose `*_TARGET_PERCENT_OF_FLYWHEEL` and `*_REFERENCE_FLYWHEEL_MOTOR_RPM` for both conveyor and kicker. 
- Implemented `IndexerSubsystem.feedForwardScaledToFlywheel(double targetFlywheelMotorRPM)` which computes desired indexer RPMs from the shooter target, converts that ratio into scaled forward voltages, and clamps to the configured peak voltages. 
- Replaced direct `conveyorForward()`/`kickerForward()` calls in `FuelCommands` with `feedForwardScaledToFlywheel(shooter.getTargetVelocityRPM())` for preset shooting, pass shooting, and pose-align-and-shoot flows. 
- Kept existing open-loop voltage control approach and limited changes to scaling logic (no closed-loop indexer control added). 

### Testing
- Ran `./gradlew test -q` in this environment which failed due to a Gradle/JDK compatibility error (`Unsupported class file major version 69`).
- No automated unit tests were executed successfully in this environment because of the build/tooling mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6d4fd1634832a983b8cde04bcbffe)