### PR TITLE
Update Limelight botpose entry to use MegaTag2 WPILib blue-origin

### DIFF
--- a/src/main/java/frc/robot/subsystems/vision/VisionIOLimelight.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOLimelight.java
@@ -25,7 +25,7 @@ import edu.wpi.first.math.util.Units;
  * - ty: Vertical offset to target in degrees
  * - ta: Target area (0-100% of image)
  * - tid: AprilTag ID
- * - botpose: Robot pose from AprilTag [x, y, z, roll, pitch, yaw]
+ * - botpose_orb_wpiblue: Robot pose (MegaTag2, WPILib blue-origin frame) [x, y, z, roll, pitch, yaw]
  * - tl: Pipeline latency (ms)
  * - cl: Capture latency (ms)
  */
@@ -59,7 +59,7 @@ public class VisionIOLimelight implements VisionIO {
         tyEntry = limelightTable.getEntry("ty");
         taEntry = limelightTable.getEntry("ta");
         tagIdEntry = limelightTable.getEntry("tid");
-        botposeEntry = limelightTable.getEntry("botpose");
+        botposeEntry = limelightTable.getEntry("botpose_orb_wpiblue");
         pipelineLatencyEntry = limelightTable.getEntry("tl");
         captureLatencyEntry = limelightTable.getEntry("cl");
         ledModeEntry = limelightTable.getEntry("ledMode");


### PR DESCRIPTION
## Summary
Updated the Limelight vision subsystem to use the `botpose_orb_wpiblue` network table entry instead of the generic `botpose` entry, enabling MegaTag2 pose estimation with WPILib's blue-origin coordinate frame.

## Key Changes
- Changed the botpose network table entry from `"botpose"` to `"botpose_orb_wpiblue"`
- Updated the documentation comment to clarify that this entry provides robot pose from MegaTag2 multi-tag detection in the WPILib blue-origin frame
- This aligns the vision system with WPILib's standard coordinate frame conventions for better integration with autonomous routines and odometry

## Implementation Details
The change is minimal and focused - only the network table entry name is updated, allowing the existing pose parsing logic to work with the more accurate MegaTag2 pose estimation algorithm while maintaining consistency with WPILib's coordinate system standards.

https://claude.ai/code/session_01EiDYsdavHuao1XAs9vMzEQ