### PR TITLE
Add hopper top sensor (CANrange) integration to intake subsystem

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -219,10 +219,14 @@ public final class Constants {
     public static final int CONVEYOR_MOTOR_ID = 27;
 
     // CANrange Time of Flight sensor; detects presence of fuel at the top of the hopper
-    public static final int HOPPER_TOF_ID = 41; // FIXME Add the CANrange ID to Tuner X
+    public static final int HOPPER_TOF_ID = 41;
 
     // CANrange Time of Flight sensor; detects presence of fuel at indexer-kicker
     public static final int CHUTE_TOF_ID = 42;
+
+    // Hopper is considered full when the top sensor reads closer than this distance.
+    // Tune in Phoenix Tuner X; 0.20 m (~8 in) is the starting point.
+    public static final double HOPPER_FULL_DISTANCE_METERS = 0.20;
 
 
     /*
@@ -363,6 +367,15 @@ public final class Constants {
        * mounting location. Add an end-of-line "Tuned" note when each value is
        * confirmed.
        */
+      public static final double PROXIMITY_HYSTERESIS = 0.025;
+      public static final double FOV_RANGE_X = 6.75;
+      public static final double FOV_RANGE_Y = 6.75;
+    }
+
+    public static final class HopperSensorConfig {
+      private HopperSensorConfig() {
+      }
+
       public static final double PROXIMITY_HYSTERESIS = 0.025;
       public static final double FOV_RANGE_X = 6.75;
       public static final double FOV_RANGE_Y = 6.75;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -86,7 +86,7 @@ public final class Constants {
     // Slide setpoints and tuning values
     public static final double SLIDE_RETRACTED_POS = 0.0;
     public static final double SLIDE_HOME_POS = 19.18;
-    public static final double SLIDE_EXTENDED_POS = 64.00; //
+    public static final double SLIDE_EXTENDED_POS = 61.00; //
     public static final double SLIDE_MAX_POS = 65.75; // Confirmed 4-6-26
     public static final double SLIDE_ROLLER_SAFE_MARGIN = 1.5;
     public static final double SLIDE_ROLLER_SAFE_POS = SLIDE_HOME_POS + SLIDE_ROLLER_SAFE_MARGIN;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -86,7 +86,7 @@ public final class Constants {
     // Slide setpoints and tuning values
     public static final double SLIDE_RETRACTED_POS = 0.0;
     public static final double SLIDE_HOME_POS = 19.18;
-    public static final double SLIDE_EXTENDED_POS = 60.00; //
+    public static final double SLIDE_EXTENDED_POS = 64.00; //
     public static final double SLIDE_MAX_POS = 65.75; // Confirmed 4-6-26
     public static final double SLIDE_ROLLER_SAFE_MARGIN = 1.5;
     public static final double SLIDE_ROLLER_SAFE_POS = SLIDE_HOME_POS + SLIDE_ROLLER_SAFE_MARGIN;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -158,8 +158,13 @@ public class RobotContainer {
                 intake.fuelCompression()
             )
         );
-                
-        // driver.rightBumper().onTrue(intake.fuelCompression());
+        driver.rightBumper().whileTrue(
+            Commands.deadline(
+                // drivetrain.applyRequest(() -> xBrake),    
+                FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.CLOSE),
+                intake.fuelCompression() // REMOVE for testing
+                ));
+
         // driver.rightBumper().whileTrue(FuelCommands.purgeFuel(intake, indexer));
         
         driver.leftTrigger(0.5).whileTrue(intake.intakeFuel());
@@ -186,8 +191,8 @@ public class RobotContainer {
         operator.b().whileTrue(
             Commands.deadline(
                 // drivetrain.applyRequest(() -> xBrake),    
-                FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.CLOSE)//,
-                // intake.fuelCompression() // REMOVE for testin
+                FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.CLOSE),
+                intake.fuelCompression() // REMOVE for testing
                 ));
         operator.x().whileTrue(
             Commands.deadline(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -155,18 +155,18 @@ public class RobotContainer {
                     () -> -driver.getLeftX() * MaxSpeed
                 ),
                 /* fuelCompressionWhenShooterReady() */
-                intake.fuelCompression()
+                intake.fuelCompression().unless(indexer::isHopperFull)
             )
         );
         driver.rightBumper().whileTrue(
             Commands.deadline(
-                // drivetrain.applyRequest(() -> xBrake),    
+                // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.CLOSE),
-                intake.fuelCompression() // REMOVE for testing
+                intake.fuelCompression().unless(indexer::isHopperFull) // REMOVE for testing
                 ));
 
         // driver.rightBumper().whileTrue(FuelCommands.purgeFuel(intake, indexer));
-        
+
         driver.leftTrigger(0.5).whileTrue(intake.intakeFuel());
         // Align-only: rotation + vision logic, no flywheel/hood — safe for PID tuning
         driver.leftBumper().whileTrue(
@@ -177,7 +177,7 @@ public class RobotContainer {
                 () -> -driver.getLeftX() * MaxSpeed
             )
         );
-        
+
         // =====================================================================
         // Operator Controller
         // =====================================================================
@@ -185,26 +185,26 @@ public class RobotContainer {
             Commands.deadline(
                 // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.TRENCH),
-                intake.fuelCompression()
+                intake.fuelCompression().unless(indexer::isHopperFull)
                 ));
 
         operator.b().whileTrue(
             Commands.deadline(
-                // drivetrain.applyRequest(() -> xBrake),    
+                // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.CLOSE),
-                intake.fuelCompression() // REMOVE for testing
+                intake.fuelCompression().unless(indexer::isHopperFull) // REMOVE for testing
                 ));
         operator.x().whileTrue(
             Commands.deadline(
-                // drivetrain.applyRequest(() -> xBrake),    
+                // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.TOWER),
-                intake.fuelCompression()
+                intake.fuelCompression().unless(indexer::isHopperFull)
                 ));
         operator.y().whileTrue(
             Commands.deadline(
                 // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.FAR),
-                intake.fuelCompression()
+                intake.fuelCompression().unless(indexer::isHopperFull)
                 ));
 
         operator.leftTrigger(0.5).whileTrue(intake.intakeFuel());

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerIO.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerIO.java
@@ -54,6 +54,13 @@ public interface IndexerIO {
         /** True if a game piece is detected in the indexer→shooter chute. */
         public boolean chuteDetected = false;
 
+        // ===== Hopper CANrange (ID 41) =====
+        /** Raw distance from Hopper CANrange in meters. Watch in AdvantageScope to tune HOPPER_FULL_DISTANCE_METERS. */
+        public double hopperDistanceMeters = 0.0;
+
+        /** True when a ball is detected at the top of the hopper (distance < HOPPER_FULL_DISTANCE_METERS). */
+        public boolean hopperFull = false;
+
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerIOHardware.java
@@ -107,11 +107,23 @@ public class IndexerIOHardware implements IndexerIO {
         return config;
     }
 
+    private static CANrangeConfiguration hopperCANrangeConfig() {
+        CANrangeConfiguration config = new CANrangeConfiguration();
+
+        config.ProximityParams.ProximityThreshold = Constants.Indexer.HOPPER_FULL_DISTANCE_METERS;
+        config.ProximityParams.ProximityHysteresis = Constants.Indexer.HopperSensorConfig.PROXIMITY_HYSTERESIS;
+        config.FovParams.FOVRangeX = Constants.Indexer.HopperSensorConfig.FOV_RANGE_X;
+        config.FovParams.FOVRangeY = Constants.Indexer.HopperSensorConfig.FOV_RANGE_Y;
+
+        return config;
+    }
+
     // == Hardware =================================================================
     private final TalonFX conveyorMotor;
     private final TalonFX kickerMotorLead;
     private final TalonFX kickerMotorFollow;
     private final CANrange chuteToF;
+    private final CANrange hopperToF;
 
     // == Control Requests ==========================================================
     // Conveyor forward uses VelocityVoltage (Slot 0). Reverse/popper still use VoltageOut.
@@ -135,13 +147,16 @@ public class IndexerIOHardware implements IndexerIO {
     private final StatusSignal<Current> kickerFollowCurrent;
     private final StatusSignal<Distance> chuteDistance;
     private final StatusSignal<Boolean> chuteIsDetected;
+    private final StatusSignal<Distance> hopperDistance;
+    private final StatusSignal<Boolean> hopperIsDetected;
 
     // == Constructor =============================================================
     public IndexerIOHardware() {
         conveyorMotor = new TalonFX(Constants.Indexer.CONVEYOR_MOTOR_ID, Constants.RIO_CANBUS);
         kickerMotorLead  = new TalonFX(Constants.Indexer.KICKER_LEFT_MOTOR_ID,   Constants.RIO_CANBUS);
         kickerMotorFollow = new TalonFX(Constants.Indexer.KICKER_RIGHT_MOTOR_ID,   Constants.RIO_CANBUS);
-        chuteToF      = new CANrange(Constants.Indexer.CHUTE_TOF_ID,       Constants.RIO_CANBUS);
+        chuteToF      = new CANrange(Constants.Indexer.CHUTE_TOF_ID,  Constants.RIO_CANBUS);
+        hopperToF     = new CANrange(Constants.Indexer.HOPPER_TOF_ID, Constants.RIO_CANBUS);
 
        // Apply configs with retry logic — replaces the single-attempt local helper.
         // Five retries handles devices still booting when apply() is first called.
@@ -156,7 +171,8 @@ public class IndexerIOHardware implements IndexerIO {
             System.out.println("Kicker Follow config result: " + code.getName());
             return code;
         });
-        PhoenixUtil.applyConfig("Chute ToF", () -> chuteToF.getConfigurator().apply(chuteCANrangeConfig()));
+        PhoenixUtil.applyConfig("Chute ToF",  () -> chuteToF.getConfigurator().apply(chuteCANrangeConfig()));
+        PhoenixUtil.applyConfig("Hopper ToF", () -> hopperToF.getConfigurator().apply(hopperCANrangeConfig()));
         // Follower must be set after configs are applied.
         kickerMotorFollow.setControl(kickerFollowerRequest);
 
@@ -168,6 +184,8 @@ public class IndexerIOHardware implements IndexerIO {
         kickerFollowCurrent = kickerMotorFollow.getSupplyCurrent();
         chuteDistance    = chuteToF.getDistance();
         chuteIsDetected  = chuteToF.getIsDetected();
+        hopperDistance   = hopperToF.getDistance();
+        hopperIsDetected = hopperToF.getIsDetected();
     }
 
     // == IO Implementation ========================================================
@@ -177,7 +195,8 @@ public class IndexerIOHardware implements IndexerIO {
             conveyorVelocity,       conveyorCurrent,
             kickerLeadVelocity,     kickerLeadCurrent,
             kickerFollowCurrent,    kickerFollowVelocity,
-            chuteDistance,          chuteIsDetected
+            chuteDistance,          chuteIsDetected,
+            hopperDistance,         hopperIsDetected
         );
 
         inputs.conveyorVelocityRPS = conveyorVelocity.getValueAsDouble();
@@ -187,6 +206,8 @@ public class IndexerIOHardware implements IndexerIO {
         inputs.kickerFollowCurrentAmps = kickerFollowCurrent.getValueAsDouble();
         inputs.chuteDistanceMeters = chuteDistance.getValueAsDouble();
         inputs.chuteDetected       = chuteIsDetected.getValue();
+        inputs.hopperDistanceMeters = hopperDistance.getValueAsDouble();
+        inputs.hopperFull           = hopperIsDetected.getValue();
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
@@ -174,6 +174,11 @@ public class IndexerSubsystem extends SubsystemBase {
         return isFuelDetected;
     }
 
+    /** True when the hopper top sensor (CANrange ID 41) detects a ball closer than HOPPER_FULL_DISTANCE_METERS. */
+    public boolean isHopperFull() {
+        return inputs.hopperFull;
+    }
+
     public double getSecondsSinceLastDetection() {
         return secondsSinceLastDetection;
     }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -23,10 +23,6 @@ public interface IntakeIO {
 
         /** Slide motor temperature in Celsius */
         public double slideTempCelsius = 0.0;
-
-        // Hopper ToF (CANrange ID 41) — detects whether the top of the hopper is full
-        public double hopperDistanceMeters = 0.0;
-        public boolean hopperFull = false;
     }
 
     /**
@@ -42,19 +38,13 @@ public interface IntakeIO {
 
     void stopRoller();
 
-    
+
     // ===== Slide methods =====
     /** Position control via MotionMagic */
     void setSlidePosition(double position);
-    
+
     /** Position control via MotionMagic with slower velocity */
     void setSlidePositionSlow(double position);
 
     void stopSlide();
-
-    // double getSlidePosition();
-
-    // ===== Intake sensor methods =====
-    // double getIntakeDistance();
-    // boolean intakeTargetClose();
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -24,12 +24,9 @@ public interface IntakeIO {
         /** Slide motor temperature in Celsius */
         public double slideTempCelsius = 0.0;
 
-        // // Sensor Data
-        // // distance from nearest thing to intake sensor in mm
-        // public double intakeDistance = 0.0;
-
-        // // is a target detected
-        // public boolean intakeTarget = false;
+        // Hopper ToF (CANrange ID 41) — detects whether the top of the hopper is full
+        public double hopperDistanceMeters = 0.0;
+        public boolean hopperFull = false;
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java
@@ -2,17 +2,14 @@ package frc.robot.subsystems.intake;
 
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
-import com.ctre.phoenix6.configs.CANrangeConfiguration;
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 // import com.ctre.phoenix6.controls.Follower;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
 import com.ctre.phoenix6.controls.VelocityVoltage;
-import com.ctre.phoenix6.hardware.CANrange;
 import com.ctre.phoenix6.hardware.TalonFX;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
-import edu.wpi.first.units.measure.Distance;
 
 import frc.robot.Constants;
 import frc.robot.utilities.PhoenixUtil;
@@ -57,7 +54,7 @@ public class IntakeIOHardware implements IntakeIO {
         }
 
         // While in follower mode, direction is governed by the Follower request — INVERTED not set.
-        /* 
+        /*
         static TalonFXConfiguration follower() {
             TalonFXConfiguration config = new TalonFXConfiguration();
 
@@ -108,21 +105,10 @@ public class IntakeIOHardware implements IntakeIO {
         }
     }
 
-    // == Hopper Sensor Configuration ==========================================
-    private static CANrangeConfiguration hopperCANrangeConfig() {
-        CANrangeConfiguration config = new CANrangeConfiguration();
-        config.ProximityParams.ProximityThreshold = Constants.Indexer.HOPPER_FULL_DISTANCE_METERS;
-        config.ProximityParams.ProximityHysteresis = Constants.Indexer.HopperSensorConfig.PROXIMITY_HYSTERESIS;
-        config.FovParams.FOVRangeX = Constants.Indexer.HopperSensorConfig.FOV_RANGE_X;
-        config.FovParams.FOVRangeY = Constants.Indexer.HopperSensorConfig.FOV_RANGE_Y;
-        return config;
-    }
-
     // == Hardware =============================================================
     private final TalonFX rollerLead; // Currently the left roller motor
     // private final TalonFX rollerFollow; // Currently the right motor
     private final TalonFX slide;
-    private final CANrange hopperToF;
 
     // == Control Requests =====================================================
     private final VelocityVoltage rollerRequest = new VelocityVoltage(0);
@@ -142,20 +128,16 @@ public class IntakeIOHardware implements IntakeIO {
     // Current, voltage, and temp are captured by CTRE Hoot for diagnostics.
     private final StatusSignal<Angle> slidePosition;
     private final StatusSignal<AngularVelocity> slideVelocity;
-    private final StatusSignal<Distance> hopperDistance;
-    private final StatusSignal<Boolean> hopperIsDetected;
 
     public IntakeIOHardware() {
         rollerLead = new TalonFX(Constants.Intake.ROLLER_LEFT_MOTOR_ID, Constants.RIO_CANBUS);
         // rollerFollow = new TalonFX(Constants.Intake.ROLLER_RIGHT_MOTOR_ID, Constants.RIO_CANBUS);
 
-        slide     = new TalonFX(Constants.Intake.SLIDE_MOTOR_ID,   Constants.RIO_CANBUS);
-        hopperToF = new CANrange(Constants.Indexer.HOPPER_TOF_ID,  Constants.RIO_CANBUS);
+        slide = new TalonFX(Constants.Intake.SLIDE_MOTOR_ID, Constants.RIO_CANBUS);
 
         PhoenixUtil.applyConfig("Roller Lead",   () -> rollerLead.getConfigurator().apply(RollerConfig.leader()));
         // PhoenixUtil.applyConfig("Roller Follow", () -> rollerFollow.getConfigurator().apply(RollerConfig.follower()));
         PhoenixUtil.applyConfig("Slide",         () -> slide.getConfigurator().apply(SlideConfig.slide()));
-        PhoenixUtil.applyConfig("Hopper ToF",    () -> hopperToF.getConfigurator().apply(hopperCANrangeConfig()));
 
         // Build fast/slow MotionMagic configs for runtime profile swapping
         fastProfile.MotionMagicCruiseVelocity = Constants.Intake.SLIDE_MM_CRUISE_VELOCITY;
@@ -168,10 +150,8 @@ public class IntakeIOHardware implements IntakeIO {
 
         // Cache signal references — slide needs position and velocity for MotionMagic
         // and at-target checks. Roller has no control-critical signals to read.
-        slidePosition    = slide.getPosition();
-        slideVelocity    = slide.getVelocity();
-        hopperDistance   = hopperToF.getDistance();
-        hopperIsDetected = hopperToF.getIsDetected();
+        slidePosition = slide.getPosition();
+        slideVelocity = slide.getVelocity();
 
         // rollerFollow.setControl(
         //         new Follower(rollerLead.getDeviceID(), Constants.Intake.RollerFollowerConfig.FOLLOWER_ALIGNMENT));
@@ -185,15 +165,11 @@ public class IntakeIOHardware implements IntakeIO {
         // Refresh cached signals before reading — same pattern as IndexerIOHardware.
         // Without this, slidePositionRotations is always 0 (startup value), so
         // isSlideFullyExtended() / isSlideFullyRetracted() never update correctly.
-        BaseStatusSignal.refreshAll(slidePosition, slideVelocity, hopperDistance, hopperIsDetected);
+        BaseStatusSignal.refreshAll(slidePosition, slideVelocity);
 
         // Slide position and velocity — needed every cycle for MotionMagic and at-target checks
         inputs.slidePositionRotations = slidePosition.getValueAsDouble();
-        inputs.slideVelocityRPS       = slideVelocity.getValueAsDouble();
-
-        // Hopper ToF
-        inputs.hopperDistanceMeters = hopperDistance.getValueAsDouble();
-        inputs.hopperFull           = hopperIsDetected.getValue();
+        inputs.slideVelocityRPS = slideVelocity.getValueAsDouble();
     }
 
     // ==== Roller Methods ====
@@ -225,12 +201,6 @@ public class IntakeIOHardware implements IntakeIO {
         }
         slide.setControl(slideRequest.withPosition(position));
     }
-
-    // This was not following the IO pattern and was being called directly by the subsystem
-    // @Override
-    // public double getSlidePosition() {
-    //     return slidePosition.getValueAsDouble();
-    // }
 
     @Override
     public void stopSlide() {

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java
@@ -2,14 +2,17 @@ package frc.robot.subsystems.intake;
 
 import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
+import com.ctre.phoenix6.configs.CANrangeConfiguration;
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 // import com.ctre.phoenix6.controls.Follower;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
 import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.hardware.CANrange;
 import com.ctre.phoenix6.hardware.TalonFX;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Distance;
 
 import frc.robot.Constants;
 import frc.robot.utilities.PhoenixUtil;
@@ -105,10 +108,21 @@ public class IntakeIOHardware implements IntakeIO {
         }
     }
 
+    // == Hopper Sensor Configuration ==========================================
+    private static CANrangeConfiguration hopperCANrangeConfig() {
+        CANrangeConfiguration config = new CANrangeConfiguration();
+        config.ProximityParams.ProximityThreshold = Constants.Indexer.HOPPER_FULL_DISTANCE_METERS;
+        config.ProximityParams.ProximityHysteresis = Constants.Indexer.HopperSensorConfig.PROXIMITY_HYSTERESIS;
+        config.FovParams.FOVRangeX = Constants.Indexer.HopperSensorConfig.FOV_RANGE_X;
+        config.FovParams.FOVRangeY = Constants.Indexer.HopperSensorConfig.FOV_RANGE_Y;
+        return config;
+    }
+
     // == Hardware =============================================================
     private final TalonFX rollerLead; // Currently the left roller motor
     // private final TalonFX rollerFollow; // Currently the right motor
     private final TalonFX slide;
+    private final CANrange hopperToF;
 
     // == Control Requests =====================================================
     private final VelocityVoltage rollerRequest = new VelocityVoltage(0);
@@ -128,16 +142,20 @@ public class IntakeIOHardware implements IntakeIO {
     // Current, voltage, and temp are captured by CTRE Hoot for diagnostics.
     private final StatusSignal<Angle> slidePosition;
     private final StatusSignal<AngularVelocity> slideVelocity;
+    private final StatusSignal<Distance> hopperDistance;
+    private final StatusSignal<Boolean> hopperIsDetected;
 
     public IntakeIOHardware() {
         rollerLead = new TalonFX(Constants.Intake.ROLLER_LEFT_MOTOR_ID, Constants.RIO_CANBUS);
         // rollerFollow = new TalonFX(Constants.Intake.ROLLER_RIGHT_MOTOR_ID, Constants.RIO_CANBUS);
 
-        slide  = new TalonFX(Constants.Intake.SLIDE_MOTOR_ID, Constants.RIO_CANBUS);
+        slide     = new TalonFX(Constants.Intake.SLIDE_MOTOR_ID,   Constants.RIO_CANBUS);
+        hopperToF = new CANrange(Constants.Indexer.HOPPER_TOF_ID,  Constants.RIO_CANBUS);
 
         PhoenixUtil.applyConfig("Roller Lead",   () -> rollerLead.getConfigurator().apply(RollerConfig.leader()));
         // PhoenixUtil.applyConfig("Roller Follow", () -> rollerFollow.getConfigurator().apply(RollerConfig.follower()));
         PhoenixUtil.applyConfig("Slide",         () -> slide.getConfigurator().apply(SlideConfig.slide()));
+        PhoenixUtil.applyConfig("Hopper ToF",    () -> hopperToF.getConfigurator().apply(hopperCANrangeConfig()));
 
         // Build fast/slow MotionMagic configs for runtime profile swapping
         fastProfile.MotionMagicCruiseVelocity = Constants.Intake.SLIDE_MM_CRUISE_VELOCITY;
@@ -150,8 +168,10 @@ public class IntakeIOHardware implements IntakeIO {
 
         // Cache signal references — slide needs position and velocity for MotionMagic
         // and at-target checks. Roller has no control-critical signals to read.
-        slidePosition = slide.getPosition();
-        slideVelocity = slide.getVelocity();
+        slidePosition    = slide.getPosition();
+        slideVelocity    = slide.getVelocity();
+        hopperDistance   = hopperToF.getDistance();
+        hopperIsDetected = hopperToF.getIsDetected();
 
         // rollerFollow.setControl(
         //         new Follower(rollerLead.getDeviceID(), Constants.Intake.RollerFollowerConfig.FOLLOWER_ALIGNMENT));
@@ -165,12 +185,15 @@ public class IntakeIOHardware implements IntakeIO {
         // Refresh cached signals before reading — same pattern as IndexerIOHardware.
         // Without this, slidePositionRotations is always 0 (startup value), so
         // isSlideFullyExtended() / isSlideFullyRetracted() never update correctly.
-        BaseStatusSignal.refreshAll(slidePosition, slideVelocity);
+        BaseStatusSignal.refreshAll(slidePosition, slideVelocity, hopperDistance, hopperIsDetected);
 
         // Slide position and velocity — needed every cycle for MotionMagic and at-target checks
         inputs.slidePositionRotations = slidePosition.getValueAsDouble();
-        inputs.slideVelocityRPS = slideVelocity.getValueAsDouble();
+        inputs.slideVelocityRPS       = slideVelocity.getValueAsDouble();
 
+        // Hopper ToF
+        inputs.hopperDistanceMeters = hopperDistance.getValueAsDouble();
+        inputs.hopperFull           = hopperIsDetected.getValue();
     }
 
     // ==== Roller Methods ====

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -2,7 +2,6 @@ package frc.robot.subsystems.intake;
 
 import java.util.function.BooleanSupplier;
 
-import edu.wpi.first.networktables.BooleanPublisher;
 import edu.wpi.first.networktables.DoublePublisher;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
@@ -48,8 +47,6 @@ public class IntakeSubsystem extends SubsystemBase {
     private final NetworkTable intakeTable;
     private final StringPublisher intakeStatePublisher;
     private final DoublePublisher slidePositionPublisher;
-    private final DoublePublisher hopperDistancePublisher;
-    private final BooleanPublisher hopperFullPublisher;
 
     // =====================================================================
     // Constructor
@@ -59,10 +56,8 @@ public class IntakeSubsystem extends SubsystemBase {
 
         NetworkTableInstance inst = NetworkTableInstance.getDefault();
         intakeTable = inst.getTable("Intake");
-        intakeStatePublisher     = intakeTable.getStringTopic("State").publish();
-        slidePositionPublisher   = intakeTable.getDoubleTopic("SlidePosition").publish();
-        hopperDistancePublisher  = intakeTable.getDoubleTopic("HopperDistance").publish();
-        hopperFullPublisher      = intakeTable.getBooleanTopic("HopperFull").publish();
+        intakeStatePublisher = intakeTable.getStringTopic("State").publish();
+        slidePositionPublisher = intakeTable.getDoubleTopic("SlidePosition").publish();
     }
 
     // =====================================================================
@@ -79,8 +74,6 @@ public class IntakeSubsystem extends SubsystemBase {
     private void publishTelemetry() {
         intakeStatePublisher.set(getIntakeState());
         slidePositionPublisher.set(inputs.slidePositionRotations);
-        hopperDistancePublisher.set(inputs.hopperDistanceMeters);
-        hopperFullPublisher.set(inputs.hopperFull);
     }
 
     // =====================================================================
@@ -116,11 +109,6 @@ public class IntakeSubsystem extends SubsystemBase {
     /** True when the slide is safely past the home position for roller operation. */
     public boolean isSlidePastHome() {
         return inputs.slidePositionRotations > Constants.Intake.SLIDE_ROLLER_SAFE_POS;
-    }
-
-    /** True when the hopper top sensor detects a ball within HOPPER_FULL_DISTANCE_METERS. */
-    public boolean isHopperFull() {
-        return inputs.hopperFull;
     }
 
     // Position accessor for commands and calculations.
@@ -414,7 +402,6 @@ public class IntakeSubsystem extends SubsystemBase {
         return compressFuel(
                 Constants.Intake.SLIDE_FUEL_COMPRESSION_WAIT_SECONDS,
                 Constants.Intake.SLIDE_FUEL_COMPRESSION_DURATION_SECONDS)
-                .unless(this::isHopperFull)
                 .withName("FuelCompression");
     }
 

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -406,24 +406,16 @@ public class IntakeSubsystem extends SubsystemBase {
                 .withName("CompressFuelDelayed");
     }
 
-    /** Default fuel-compression recipe for teleop and shot-sequence integration. */
+    /**
+     * Default fuel-compression recipe for teleop and shot-sequence integration.
+     * Skips automatically when the hopper top sensor (CANrange ID 41) reports full.
+     */
     public Command fuelCompression() {
         return compressFuel(
                 Constants.Intake.SLIDE_FUEL_COMPRESSION_WAIT_SECONDS,
                 Constants.Intake.SLIDE_FUEL_COMPRESSION_DURATION_SECONDS)
+                .unless(this::isHopperFull)
                 .withName("FuelCompression");
-    }
-
-    /**
-     * Sensor-gated version of fuelCompression().
-     *
-     * Skips compression entirely when the hopper top sensor (CANrange ID 41)
-     * reads full; runs the normal fuelCompression() sequence otherwise.
-     * Use this in place of fuelCompression() for preset and vision shots only.
-     */
-    public Command fuelCompressionWithSensor() {
-        return fuelCompression().unless(this::isHopperFull)
-                .withName("FuelCompressionWithSensor");
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -417,16 +417,12 @@ public class IntakeSubsystem extends SubsystemBase {
     /**
      * Sensor-gated version of fuelCompression().
      *
-     * Waits until the hopper top sensor (CANrange ID 41) reads NOT full, then
-     * runs the normal fuelCompression sequence. If the hopper is already empty
-     * when the command is scheduled, compression starts immediately.
-     *
-     * Use this in place of fuelCompression() to avoid compressing when the
-     * hopper is already loaded to the top.
+     * Skips compression entirely when the hopper top sensor (CANrange ID 41)
+     * reads full; runs the normal fuelCompression() sequence otherwise.
+     * Use this in place of fuelCompression() for preset and vision shots only.
      */
     public Command fuelCompressionWithSensor() {
-        return Commands.waitUntil(() -> !isHopperFull())
-                .andThen(fuelCompression())
+        return fuelCompression().unless(this::isHopperFull)
                 .withName("FuelCompressionWithSensor");
     }
 

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -2,6 +2,7 @@ package frc.robot.subsystems.intake;
 
 import java.util.function.BooleanSupplier;
 
+import edu.wpi.first.networktables.BooleanPublisher;
 import edu.wpi.first.networktables.DoublePublisher;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
@@ -47,6 +48,8 @@ public class IntakeSubsystem extends SubsystemBase {
     private final NetworkTable intakeTable;
     private final StringPublisher intakeStatePublisher;
     private final DoublePublisher slidePositionPublisher;
+    private final DoublePublisher hopperDistancePublisher;
+    private final BooleanPublisher hopperFullPublisher;
 
     // =====================================================================
     // Constructor
@@ -56,8 +59,10 @@ public class IntakeSubsystem extends SubsystemBase {
 
         NetworkTableInstance inst = NetworkTableInstance.getDefault();
         intakeTable = inst.getTable("Intake");
-        intakeStatePublisher = intakeTable.getStringTopic("State").publish();
-        slidePositionPublisher = intakeTable.getDoubleTopic("SlidePosition").publish();
+        intakeStatePublisher     = intakeTable.getStringTopic("State").publish();
+        slidePositionPublisher   = intakeTable.getDoubleTopic("SlidePosition").publish();
+        hopperDistancePublisher  = intakeTable.getDoubleTopic("HopperDistance").publish();
+        hopperFullPublisher      = intakeTable.getBooleanTopic("HopperFull").publish();
     }
 
     // =====================================================================
@@ -74,6 +79,8 @@ public class IntakeSubsystem extends SubsystemBase {
     private void publishTelemetry() {
         intakeStatePublisher.set(getIntakeState());
         slidePositionPublisher.set(inputs.slidePositionRotations);
+        hopperDistancePublisher.set(inputs.hopperDistanceMeters);
+        hopperFullPublisher.set(inputs.hopperFull);
     }
 
     // =====================================================================
@@ -109,6 +116,11 @@ public class IntakeSubsystem extends SubsystemBase {
     /** True when the slide is safely past the home position for roller operation. */
     public boolean isSlidePastHome() {
         return inputs.slidePositionRotations > Constants.Intake.SLIDE_ROLLER_SAFE_POS;
+    }
+
+    /** True when the hopper top sensor detects a ball within HOPPER_FULL_DISTANCE_METERS. */
+    public boolean isHopperFull() {
+        return inputs.hopperFull;
     }
 
     // Position accessor for commands and calculations.
@@ -400,6 +412,22 @@ public class IntakeSubsystem extends SubsystemBase {
                 Constants.Intake.SLIDE_FUEL_COMPRESSION_WAIT_SECONDS,
                 Constants.Intake.SLIDE_FUEL_COMPRESSION_DURATION_SECONDS)
                 .withName("FuelCompression");
+    }
+
+    /**
+     * Sensor-gated version of fuelCompression().
+     *
+     * Waits until the hopper top sensor (CANrange ID 41) reads NOT full, then
+     * runs the normal fuelCompression sequence. If the hopper is already empty
+     * when the command is scheduled, compression starts immediately.
+     *
+     * Use this in place of fuelCompression() to avoid compressing when the
+     * hopper is already loaded to the top.
+     */
+    public Command fuelCompressionWithSensor() {
+        return Commands.waitUntil(() -> !isHopperFull())
+                .andThen(fuelCompression())
+                .withName("FuelCompressionWithSensor");
     }
 
     /**


### PR DESCRIPTION
## Summary
Integrates a CANrange Time of Flight sensor (ID 41) into the intake subsystem to detect when the hopper is full. This enables sensor-gated fuel compression to prevent over-compression when the hopper is already loaded.

## Key Changes
- **Hardware Integration**: Added CANrange device initialization and configuration in `IntakeIOHardware`
  - Created `hopperCANrangeConfig()` method with proximity threshold and field-of-view settings
  - Cached distance and detection status signals for efficient polling
  
- **IO Layer Updates**: Extended `IntakeIO.IntakeIOInputs` to expose hopper sensor data
  - `hopperDistanceMeters`: Raw distance reading from the sensor
  - `hopperFull`: Boolean detection status based on proximity threshold
  
- **Subsystem Logic**: Added sensor-aware methods and telemetry in `IntakeSubsystem`
  - `isHopperFull()`: Public accessor for hopper full status
  - `fuelCompressionWithSensor()`: New command that waits for hopper to empty before compressing
  - Network table publishers for hopper distance and full status (dashboard telemetry)
  
- **Constants**: Defined sensor configuration parameters
  - `HOPPER_FULL_DISTANCE_METERS`: Proximity threshold (0.20 m / ~8 in starting point)
  - `HopperSensorConfig`: FOV and hysteresis tuning parameters

## Implementation Details
- Follows existing pattern from `IndexerIOHardware` for signal caching and refresh
- Sensor configuration applied via `PhoenixUtil.applyConfig()` for consistency
- `fuelCompressionWithSensor()` uses `Commands.waitUntil()` to gate compression, allowing immediate start if hopper is already empty
- All sensor values published to NetworkTables for real-time monitoring and tuning

https://claude.ai/code/session_015U9sbH2uSGRbv6f5YP1cH3