### PR TITLE
Replace intake.fuelCompression() with fuelCompressionWhenShooterReady()

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -154,7 +154,7 @@ public class RobotContainer {
                     () -> -driver.getLeftY() * MaxSpeed,
                     () -> -driver.getLeftX() * MaxSpeed
                 ),
-                intake.fuelCompression()
+                fuelCompressionWhenShooterReady()
             )
         );
                 
@@ -178,7 +178,7 @@ public class RobotContainer {
             Commands.deadline(
                 // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.TRENCH),
-                intake.fuelCompression()
+                fuelCompressionWhenShooterReady()
                 ));
 
         operator.b().whileTrue(
@@ -189,15 +189,15 @@ public class RobotContainer {
                 ));
         operator.x().whileTrue(
             Commands.deadline(
-                // drivetrain.applyRequest(() -> xBrake),    
+                // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.TOWER_FRONT),
-                intake.fuelCompression()
+                fuelCompressionWhenShooterReady()
                 ));
         operator.y().whileTrue(
             Commands.deadline(
                 // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.FAR),
-                intake.fuelCompression()
+                fuelCompressionWhenShooterReady()
                 ));
 
         operator.leftTrigger(0.5).whileTrue(intake.intakeFuel());


### PR DESCRIPTION
## Summary
Refactored fuel compression command calls to use a new method that conditionally applies fuel compression based on shooter readiness state.

## Key Changes
- Replaced 4 instances of `intake.fuelCompression()` with `fuelCompressionWhenShooterReady()` across different shooting presets (TRENCH, TOWER_FRONT, FAR)
- Updated calls in the following command bindings:
  - Default drive command with fuel compression
  - Trench shot preset (operator A button)
  - Tower front shot preset (operator X button)
  - Far shot preset (operator Y button)
- Minor formatting cleanup (trailing whitespace removal on line 192)

## Implementation Details
The new `fuelCompressionWhenShooterReady()` method likely wraps the fuel compression logic with a condition that checks if the shooter is ready before executing, improving the coordination between the intake and shooter subsystems during autonomous shooting sequences.

https://claude.ai/code/session_0187zV1tVucm5hifPZWkvH3Q