### PR TITLE
Add enter/exit hysteresis and latch for flywheel at-speed detection

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -419,7 +419,11 @@ public final class Constants {
     public static final double KD = 0.000; // Tuned 4-4-2026
     public static final double KA = 0.000; // Tuned 4-4-2026
 
-    public static final double TOLERANCE_PERCENT = 0.05; //
+    // Flywheel "at speed" hysteresis window:
+    // - Enter READY when error is inside ENTER tolerance
+    // - Stay READY until error exceeds EXIT tolerance
+    public static final double TOLERANCE_ENTER_PERCENT = 0.05;
+    public static final double TOLERANCE_EXIT_PERCENT = 0.06;
 
     /* Flywheel limits */
     public static final double SUPPLY_CURRENT_LIMIT = 60;

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterSubsystem.java
@@ -97,6 +97,7 @@ public class ShooterSubsystem extends SubsystemBase {
     // private boolean standbyEnabled        = false; // operator toggled, defaults OFF at boot
     private double targetFlywheelMotorRPM = 0.0;
     private double targetHoodPoseRot      = 0.0;
+    private boolean flywheelAtVelocityLatched = false;
 
     // Slow publish divider
     private int periodicCounter = 0;
@@ -213,6 +214,9 @@ public class ShooterSubsystem extends SubsystemBase {
 
         currentState = newState;
         currentStateString = newState.toString();
+        if (newState != ShooterState.SPINNING_UP && newState != ShooterState.READY && newState != ShooterState.PASS) {
+            flywheelAtVelocityLatched = false;
+        }
 
         switch (newState) {
             case IDLE:
@@ -379,6 +383,7 @@ public class ShooterSubsystem extends SubsystemBase {
     /** Sets target flywheel velocity (forward only — clamped to MAX_FLYWHEEL_RPM). Does NOT change state. */
     public void setTargetVelocity(double rpm) {
         targetFlywheelMotorRPM = Math.min(Math.abs(rpm), Constants.Flywheel.MAX_RPM);
+        flywheelAtVelocityLatched = false;
     }
 
     /**
@@ -440,10 +445,20 @@ public class ShooterSubsystem extends SubsystemBase {
     /** Returns true if flywheel is at target velocity within tolerance. */
     public boolean isFlywheelAtVelocity() {
         if (Math.abs(targetFlywheelMotorRPM) < 1.0) {
+            flywheelAtVelocityLatched = false;
             return Math.abs(inputs.flywheelLeaderMotorRPM) < 50.0;
         }
-        double tolerance = Math.abs(targetFlywheelMotorRPM) * Constants.Flywheel.TOLERANCE_PERCENT;
-        return Math.abs(inputs.flywheelLeaderMotorRPM - targetFlywheelMotorRPM) < tolerance;
+        double error = Math.abs(inputs.flywheelLeaderMotorRPM - targetFlywheelMotorRPM);
+        double enterTolerance = Math.abs(targetFlywheelMotorRPM) * Constants.Flywheel.TOLERANCE_ENTER_PERCENT;
+        double exitTolerance = Math.abs(targetFlywheelMotorRPM) * Constants.Flywheel.TOLERANCE_EXIT_PERCENT;
+
+        if (flywheelAtVelocityLatched) {
+            flywheelAtVelocityLatched = error < exitTolerance;
+        } else {
+            flywheelAtVelocityLatched = error < enterTolerance;
+        }
+
+        return flywheelAtVelocityLatched;
     }
 
     /** Returns true if hood is at target pose within tolerance. */


### PR DESCRIPTION
### Motivation

- Prevent rapid flipping of the flywheel "at speed" status by adding a hysteresis window so the READY detection is stable during small RPM fluctuations.
- Ensure the latched ready state is cleared on relevant state changes and when targets are updated to avoid stale readiness signals.
- Replace a single tolerance value with separate entry/exit tolerances to allow different thresholds for entering and leaving the READY state.

### Description

- Replaced `TOLERANCE_PERCENT` with `TOLERANCE_ENTER_PERCENT` and `TOLERANCE_EXIT_PERCENT` and added comments describing the enter/exit hysteresis semantics in `Constants.Flywheel`.
- Added a `flywheelAtVelocityLatched` field in `ShooterSubsystem` and clear it when the state changes away from `SPINNING_UP`, `READY`, or `PASS`, and when the target velocity is set or effectively zero.
- Reworked `isFlywheelAtVelocity()` to special-case near-zero targets and to compute and update the latched state using enter/exit tolerances instead of an instantaneous comparison.

### Testing

- Ran a full project build with `./gradlew build` which completed successfully.
- Executed unit tests with `./gradlew test` and the test suite passed.
- Verified that compilation succeeds and there are no IDE errors after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebca36268c832a88484dd812db9296)