### PR TITLE
Move fuelCompressionWhenShooterReady helper into FuelCommands

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -155,7 +155,7 @@ public class RobotContainer {
                     () -> -driver.getLeftY() * MaxSpeed,
                     () -> -driver.getLeftX() * MaxSpeed
                 ),
-                fuelCompressionWhenShooterReady()
+                FuelCommands.fuelCompressionWhenShooterReady(shooter, intake)
             )
         );
                 
@@ -179,26 +179,26 @@ public class RobotContainer {
             Commands.deadline(
                 // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.TRENCH),
-                fuelCompressionWhenShooterReady()
+                FuelCommands.fuelCompressionWhenShooterReady(shooter, intake)
                 ));
 
         operator.b().whileTrue(
             Commands.deadline(
                 // drivetrain.applyRequest(() -> xBrake),    
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.CLOSE),
-                fuelCompressionWhenShooterReady()
+                FuelCommands.fuelCompressionWhenShooterReady(shooter, intake)
                 ));
         operator.x().whileTrue(
             Commands.deadline(
                 // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.TOWER_FRONT),
-                fuelCompressionWhenShooterReady()
+                FuelCommands.fuelCompressionWhenShooterReady(shooter, intake)
                 ));
         operator.y().whileTrue(
             Commands.deadline(
                 // drivetrain.applyRequest(() -> xBrake),
                 FuelCommands.shootWithPreset(shooter, indexer, ShooterSubsystem.ShotPreset.FAR),
-                fuelCompressionWhenShooterReady()
+                FuelCommands.fuelCompressionWhenShooterReady(shooter, intake)
                 ));
 
         operator.leftTrigger(0.5).whileTrue(intake.intakeFuel());
@@ -231,17 +231,6 @@ public class RobotContainer {
 
     public Command getAutonomousCommand() {
         return autoChooser.selectedCommand();
-    }
-
-    /**
-     * Runs intake fuel compression only after the shooter reports ready.
-     * If the shooting command is cancelled before ready, compression never starts.
-     */
-    private Command fuelCompressionWhenShooterReady() {
-        return Commands.sequence(
-                Commands.waitUntil(shooter::isReady),
-                intake.fuelCompression())
-                .withName("FuelCompressionWhenShooterReady");
     }
 
     public void updateGameData() {

--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -577,7 +577,7 @@ public class FuelCommands {
                     }).withName("Auto.PoseAlignAndShoot");
         }
 
-        private static Command fuelCompressionWhenShooterReady(
+        public static Command fuelCompressionWhenShooterReady(
                 ShooterSubsystem shooter,
                 IntakeSubsystem intake) {
             return Commands.sequence(


### PR DESCRIPTION
### Motivation
- Centralize the shooter-ready intake compression helper so multiple bindings can reuse the same implementation and avoid duplication.
- Allow other command factories to reference the helper without depending on `RobotContainer` instance state.

### Description
- Promoted `fuelCompressionWhenShooterReady` from a private helper in `RobotContainer` to `public static` in `FuelCommands` as `FuelCommands.fuelCompressionWhenShooterReady(ShooterSubsystem, IntakeSubsystem)`.
- Updated all driver/operator trigger bindings in `RobotContainer` to call `FuelCommands.fuelCompressionWhenShooterReady(shooter, intake)` instead of the removed local helper.
- Removed the duplicated private `fuelCompressionWhenShooterReady()` method from `RobotContainer`.

### Testing
- Ran `./gradlew compileJava`, which failed in this environment with `Unsupported class file major version 69` from Gradle script evaluation, so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdd8b6f84832abd8ed2936a213b20)