### PR TITLE
Use Limelight TX in auton align-and-shoot and preserve chute-sensor shot completion

### DIFF
--- a/src/main/java/frc/robot/AutoRoutines.java
+++ b/src/main/java/frc/robot/AutoRoutines.java
@@ -9,6 +9,7 @@ import frc.robot.subsystems.CommandSwerveDrivetrain;
 import frc.robot.subsystems.indexer.IndexerSubsystem;
 import frc.robot.subsystems.intake.IntakeSubsystem;
 import frc.robot.subsystems.shooter.ShooterSubsystem;
+import frc.robot.subsystems.vision.VisionSubsystem;
 
 public class AutoRoutines {
         private final AutoFactory m_factory;
@@ -16,19 +17,21 @@ public class AutoRoutines {
         private final IntakeSubsystem m_intake;
         private final IndexerSubsystem m_indexer;
         private final ShooterSubsystem m_shooter;
+        private final VisionSubsystem m_vision;
         
 
         public AutoRoutines(AutoFactory factory, 
                         CommandSwerveDrivetrain drivetrain,
                         IndexerSubsystem indexer, 
                         IntakeSubsystem intake, 
-                        ShooterSubsystem shooter) {
+                        ShooterSubsystem shooter,
+                        VisionSubsystem vision) {
                 m_factory = factory;
                 m_drivetrain = drivetrain;
                 m_indexer = indexer;
                 m_intake = intake;
                 m_shooter = shooter;
-                // m_vision = vision;
+                m_vision = vision;
         }
 
         public static final double shootTimeout = 5.0; // seconds
@@ -67,7 +70,7 @@ public class AutoRoutines {
                                                 RtRampMiddle_Alliance.cmd(),
 
                                                 // Shoot
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout),
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout),
 
                                                 // Drive to Trench
                                                 RtShootRamp_Trench.cmd()
@@ -104,7 +107,7 @@ public class AutoRoutines {
                                                 RtShootRamp.cmd(),
 
                                                 // 4. Shoot — starts only after RtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout)
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout)
                                                 )
                                 );
 
@@ -137,7 +140,7 @@ public class AutoRoutines {
                                                 RtShootRamp.cmd(),
 
                                                 // 4. Shoot — starts only after RtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout)
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout)
                                                 )
                                 );
 
@@ -172,7 +175,7 @@ public class AutoRoutines {
                                                 RtRampMiddle_Alliance.cmd(),
 
                                                 // 4. Shoot — starts only after RtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout),
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout),
 
                                                 // --- Cycle 2 ---
                                                 // 5. Back to trench
@@ -187,7 +190,7 @@ public class AutoRoutines {
                                                 RtRampMiddle_Alliance_2.cmd(),
 
                                                 // 9. Shoot (2nd) — starts only after RtShootRamp_2 fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout)
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout)
                                 ));
 
                 return routine;
@@ -224,7 +227,7 @@ public class AutoRoutines {
                                                 RtRampMiddle_Alliance.cmd(),
 
                                                 // 4. Shoot — starts only after RtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout),
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout),
 
                                                 // --- Cycle 2 ---
                                                 // 5. Back to trench
@@ -241,7 +244,7 @@ public class AutoRoutines {
                                                 RtRampMiddle_Alliance_2.cmd(),
 
                                                 // 9. Shoot (2nd) — starts only after RtShootRamp_2 fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout)
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout)
                                 ));
 
                 return routine;
@@ -291,7 +294,7 @@ public class AutoRoutines {
                                                 RtRampMiddle_Alliance.cmd(),
 
                                                 // 4. Shoot — starts only after RtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout),
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout),
 
                                                 // --- Cycle 2 ---
                                                 // 5. Back to trench
@@ -340,7 +343,7 @@ public class AutoRoutines {
                                                 RtRampMiddle_Alliance.cmd(),
 
                                                 // 4. Shoot — starts only after RtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout),
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout),
 
                                                 // --- Cycle 2 ---
                                                 // 5. Back to trench
@@ -376,7 +379,7 @@ public class AutoRoutines {
                                                                 AngryMeepMeep.cmd(),
                                                                 m_intake.intakeFuelTimer(intakeTimeout, intakeDelay)),
 
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout)
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout)
 
                                 ));
 
@@ -410,7 +413,7 @@ public class AutoRoutines {
                                                 LtRampMiddle_Alliance.cmd(),
 
                                                  // Shoot — starts only after LtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout),
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout),
 
                                                 // Drive to Trench
                                                 LtShootRamp_Trench.cmd()
@@ -455,7 +458,7 @@ public class AutoRoutines {
                                                 LtShootRamp_Trench.cmd(),
 
                                                 // 4. Shoot — starts only after LtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout),
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout),
 
                                                 // --- Cycle 2 ---
                                                 // 5. Back to trench
@@ -470,7 +473,7 @@ public class AutoRoutines {
                                                 LtRampMiddle_Alliance_2.cmd(),
 
                                                 // 8. Shoot (2nd) — starts only after LtShootRamp_2 fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout)
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout)
                                 ));
 
                 return routine;
@@ -511,7 +514,7 @@ public class AutoRoutines {
                                                 LtShootRamp_Trench.cmd(),
 
                                                 // 4. Shoot — starts only after LtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout),
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout),
 
                                         
                                                 // 5. Back to trench
@@ -528,7 +531,7 @@ public class AutoRoutines {
                                                 LtRampMiddle_Alliance_2.cmd(),
 
                                                 // 8. Shoot (2nd) — starts only after LtShootRamp_2 fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout)
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout)
                                 ));
 
                 return routine;
@@ -567,7 +570,7 @@ public class AutoRoutines {
                                                 LtShootRamp_Trench.cmd(),
 
                                                 // 4. Shoot — starts only after LtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout),
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout),
 
                                         
                                                 // 5. Back to trench
@@ -619,7 +622,7 @@ public class AutoRoutines {
                                                 LtShootRamp_Trench.cmd(),
 
                                                 // 4. Shoot — starts only after LtShootRamp fully completes
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout),
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout),
 
                                         
                                                 // 5. Back to trench
@@ -656,7 +659,7 @@ public class AutoRoutines {
                                                 
                                                 RtRampMiddle_Alliance.cmd(),
                                                 
-                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout)
+                                                FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout)
                                                 
 
                                 ));
@@ -716,7 +719,7 @@ public class AutoRoutines {
                                 ));
                 // Routine Events
                 LtTrench_Mid_Trench.atTime("Intake").onTrue(m_intake.intakeFuelTimer(intakeTimeout, intakeDelay));
-                LtTrench_Mid_Trench.atTime("Shoot").onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout));
+                LtTrench_Mid_Trench.atTime("Shoot").onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout));
                 LtTrench_Mid_Trench.atTime("FuelPump").onTrue(FuelCommands.Auto.fuelPumpCycleSensor(m_intake, m_indexer));
 
                 return routine;
@@ -756,7 +759,7 @@ public class AutoRoutines {
                 
                 // dependencies are fine in this version
                 RtTrench_RtMid_RtTrench.atTime("Shoot")
-                                .onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, shootTimeout));
+                                .onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout));
                 RtTrench_RtMid_RtTrench.atTime("FuelPump").onTrue(FuelCommands.Auto.fuelPumpCycleSensor(m_intake, m_indexer));
                 return routine;
                 }
@@ -803,8 +806,7 @@ public class AutoRoutines {
                         // Place the "Shoot" event marker at the END of the trajectory segment so the
                         // path finishes before this fires.
                         Experimental.atTime("Shoot")
-                                        .onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake,m_drivetrain,
-                                                        shootTimeout));
+                                        .onTrue(FuelCommands.Auto.poseAlignAndShoot(m_shooter, m_indexer, m_intake, m_drivetrain, m_vision, shootTimeout));
 
                         return routine;
                 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -82,7 +82,7 @@ public class RobotContainer {
             () -> Math.toDegrees(drivetrain.getState().Speeds.omegaRadiansPerSecond));
 
         autoFactory = drivetrain.createAutoFactory();
-        autoRoutines = new AutoRoutines(autoFactory,drivetrain,indexer, intake, shooter);
+        autoRoutines = new AutoRoutines(autoFactory, drivetrain, indexer, intake, shooter, vision);
         SmartDashboard.putData("AutoChooser", autoChooser);
 
         // =====================================================================

--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -504,15 +504,17 @@ public class FuelCommands {
 
         // =============================================================================
         /**
-         * Autonomous odometry-based align-and-shoot.
+         * Autonomous vision-assisted align-and-shoot.
          *
-         * Uses drivetrain odometry to compute heading error to the hub — no vision,
-         * no driver input, no lead compensation (robot is stopped).
+         * Uses Limelight TX when a single fresh tag is visible; otherwise falls back
+         * to drivetrain odometry heading to the hub. No driver input, no lead
+         * compensation (robot is stopped).
          *
          * Phase 1 (deadline): rotate toward hub + spin up shooter simultaneously.
          * Ends when heading error ≤ ALIGNMENT_TOLERANCE_DEGREES AND shooter isReady(),
          * or after a 3-second safety timeout.
-         * Phase 2: feed indexer for feedSeconds.
+         * Phase 2: feed indexer until chute sensor confirms ball passed
+         * ({@code isFuelDetected()} seen then clear), with timeout fallback.
          * finallyDo: stop indexer/conveyor, return shooter to idle.
          *
          * Use at Choreo "Shoot" event markers. Because this command requires the
@@ -523,7 +525,7 @@ public class FuelCommands {
          * @param shooter     Shooter subsystem
          * @param indexer     Indexer subsystem
          * @param drivetrain  Drivetrain (odometry pose source)
-         * @param feedSeconds How long to run the indexer/conveyor after alignment
+         * @param vision      Vision subsystem (fresh target + TX)
          * @param shotTimeout Timeout for the shooting sequence
          * @return Autonomous align-and-shoot command
          */
@@ -532,6 +534,7 @@ public class FuelCommands {
                 IndexerSubsystem indexer,
                 IntakeSubsystem intake,
                 CommandSwerveDrivetrain drivetrain,
+                VisionSubsystem vision,
                 double shotTimeout) {
 
             final SwerveRequest.FieldCentric alignRequest = new SwerveRequest.FieldCentric()
@@ -561,10 +564,20 @@ public class FuelCommands {
                                 if (shooter.getState() != ShooterSubsystem.ShooterState.READY) {
                                     shooter.beginSpinUp();
                                 }
+                                double currentHeadingDeg = pose.getRotation().getDegrees();
                                 double angleToHubDeg = Math.toDegrees(Math.atan2(dy, dx));
-                                double targetHeadingDeg = getRobotFrontTargetHeadingDegrees(angleToHubDeg, 0.0);
+                                double targetHeadingDeg;
+
+                                if (vision.hasFreshTarget() && vision.getTagCount() == 1) {
+                                    targetHeadingDeg = MathUtil.inputModulus(
+                                            currentHeadingDeg - vision.getTX() + Constants.Vision.ALIGNMENT_OFFSET_DEGREES,
+                                            -180.0, 180.0);
+                                } else {
+                                    targetHeadingDeg = getRobotFrontTargetHeadingDegrees(angleToHubDeg, 0.0);
+                                }
+
                                 headingPID.setSetpoint(targetHeadingDeg);
-                                double pidOutput = headingPID.calculate(pose.getRotation().getDegrees());
+                                double pidOutput = headingPID.calculate(currentHeadingDeg);
                                 double rotRate = headingPID.atSetpoint() ? 0.0
                                         : MathUtil.clamp(pidOutput,
                                                 -Constants.Vision.MAX_ALIGNMENT_ROTATION_RAD_PER_SEC,


### PR DESCRIPTION
### Motivation
- Align autonomous aiming behavior with teleop so the auton can use the Limelight TX when a single fresh tag is available and otherwise fall back to odometry. 
- Ensure autonomous shot completion remains sensor-gated (chute ToF) so auton advances only after the ball is seen then cleared.

### Description
- Updated `FuelCommands.Auto.poseAlignAndShoot(...)` to accept a `VisionSubsystem` parameter and use the same vision-first targeting logic as teleop: if `vision.hasFreshTarget()` and `vision.getTagCount() == 1` then compute target heading from `vision.getTX()`, otherwise fall back to the odometry-based heading. 
- Left autonomous feeding completion using the chute sensor by continuing to call `indexer.feedUntilChuteEmpty(shotTimeout)`, and clarified the method docs to note the sensor-gated behavior (`isFuelDetected()` / `isChuteEmpty()`).
- Threaded `VisionSubsystem` through auton wiring: added `m_vision` to `AutoRoutines`, updated all `poseAlignAndShoot(...)` calls to pass `m_vision`, and updated `RobotContainer` to construct `AutoRoutines` with the `vision` subsystem.
- Minor documentation updates in `FuelCommands` describing the new vision-assisted behavior and the chute-sensor-based Phase 2.

### Testing
- Attempted a local build with `./gradlew build -x test` to validate compilation, but the build failed in this environment due to a Java toolchain/classfile mismatch (`Unsupported class file major version 69`), so compile/test validation could not be completed here.
- No automated tests were run successfully in this container because of the above build/tooling issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0742ba5c832ab77d1ae430c89281)