### PR TITLE
Add autonomous shooter standby command factories

### DIFF
--- a/src/main/java/frc/robot/commands/FuelCommands.java
+++ b/src/main/java/frc/robot/commands/FuelCommands.java
@@ -34,6 +34,31 @@ import frc.robot.subsystems.vision.VisionSubsystem;
 public class FuelCommands {
 
     /**
+     * Manual standby toggle command factory.
+     *
+     * <p>Useful for binding to an EventTrigger/NamedCommand in autonomous so you can
+     * intentionally toggle the flywheel standby policy at specific points in a path.
+     */
+    public static Command toggleStandbyMode(ShooterSubsystem shooter) {
+        return Commands.runOnce(shooter::toggleStandbyMode, shooter)
+                .withName("ToggleShooterStandbyMode");
+    }
+
+    /**
+     * Explicit standby policy setter for autonomous.
+     *
+     * <p>Prefer this over raw toggle when possible in auton so command order stays
+     * deterministic even if an event is replayed or skipped.
+     */
+    public static Command setStandbyMode(ShooterSubsystem shooter, boolean enabled) {
+        return Commands.runOnce(() -> {
+            if (shooter.isStandbyEnabled() != enabled) {
+                shooter.toggleStandbyMode();
+            }
+        }, shooter).withName(enabled ? "EnableShooterStandbyMode" : "DisableShooterStandbyMode");
+    }
+
+    /**
      * Returns the hub center for the current alliance (defaults to blue if FMS not
      * connected).
      */


### PR DESCRIPTION
### Motivation
- Provide a simple, reuseable way to trigger the shooter's operator `toggleStandbyMode` from autonomous event triggers or named commands. 
- Give auton flows a deterministic option to force standby ON/OFF to avoid ambiguous state when events are replayed or skipped.

### Description
- Added `FuelCommands.toggleStandbyMode(ShooterSubsystem)` which returns a one-shot `Commands.runOnce(shooter::toggleStandbyMode, shooter)` named `ToggleShooterStandbyMode`.
- Added `FuelCommands.setStandbyMode(ShooterSubsystem, boolean)` which sets standby to the requested state (calls `toggleStandbyMode()` only if the current state differs) and is named `EnableShooterStandbyMode`/`DisableShooterStandbyMode` depending on the `enabled` argument.
- Included inline Javadoc explaining when to prefer the explicit setter in autonomous command sequences to keep behavior deterministic.

### Testing
- Executed `./gradlew compileJava` in this environment and it failed due to a Java/Gradle runtime mismatch (`Unsupported class file major version 69`).
- No other automated tests were run successfully in this environment due to the build toolchain failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2d5d24868832abb493ef4adfcee8b)