### PR TITLE
Add resetSlideEncoder method and command to intake slide

### DIFF
--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -55,6 +55,9 @@ public interface IntakeIO {
 
     void stopSlide();
 
+    /** Zeroes the slide encoder — call when slide is physically at the retracted hard stop. */
+    void resetSlideEncoder();
+
     // double getSlidePosition();
 
     // ===== Intake sensor methods =====

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOHardware.java
@@ -213,4 +213,9 @@ public class IntakeIOHardware implements IntakeIO {
     public void stopSlide() {
         slide.stopMotor();
     }
+
+    @Override
+    public void resetSlideEncoder() {
+        slide.setPosition(0);
+    }
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -198,6 +198,11 @@ public class IntakeSubsystem extends SubsystemBase {
         io.stopSlide();
     }
 
+    /** Zeroes the slide encoder. Call only when the slide is physically at the retracted hard stop. */
+    public void resetSlideEncoder() {
+        io.resetSlideEncoder();
+    }
+
     /**
      * Moves slide to an arbitrary position via MotionMagic. Motor holds after.
      * Caller is responsible for clamping to valid range.
@@ -324,6 +329,15 @@ public class IntakeSubsystem extends SubsystemBase {
     /** Retracts the slide in small repeated steps while held. */
     public Command manualSlideRetractHoldCmd() {
         return manualSlideNudgeHoldCmd(-Constants.Intake.SLIDE_MANUAL_STEP_ROTATIONS);
+    }
+
+    /**
+     * Zeroes the slide encoder (runOnce). Use only when the slide is physically
+     * at the retracted hard stop — e.g. during a known-position initialization sequence.
+     */
+    public Command resetSlideEncoderCmd() {
+        return Commands.runOnce(this::resetSlideEncoder, this)
+                .withName("ResetSlideEncoder");
     }
 
      // =========================================================================


### PR DESCRIPTION
Exposes the existing startup encoder-zero as a callable method and runOnce command so operators can re-zero the slide when it is known to be at the retracted hard stop.

https://claude.ai/code/session_014aSPaj6R5U7Zgdg7EB9Mio