### PR TITLE
Add simulation implementations for shooter, intake, indexer, and vision

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -22,13 +22,18 @@ import frc.robot.commands.AlignOnlyCommand;
 import frc.robot.commands.FuelCommands;
 import frc.robot.generated.TunerConstants;
 import frc.robot.subsystems.CommandSwerveDrivetrain;
+import edu.wpi.first.wpilibj.RobotBase;
 import frc.robot.subsystems.indexer.IndexerIOHardware;
+import frc.robot.subsystems.indexer.IndexerIOSim;
 import frc.robot.subsystems.indexer.IndexerSubsystem;
 import frc.robot.subsystems.intake.IntakeIOHardware;
+import frc.robot.subsystems.intake.IntakeIOSim;
 import frc.robot.subsystems.intake.IntakeSubsystem;
 import frc.robot.subsystems.shooter.ShooterIOHardware;
+import frc.robot.subsystems.shooter.ShooterIOSim;
 import frc.robot.subsystems.shooter.ShooterSubsystem;
 import frc.robot.subsystems.vision.VisionIOLimelight;
+import frc.robot.subsystems.vision.VisionIOSim;
 import frc.robot.subsystems.vision.VisionSubsystem;
 import frc.robot.utilities.GameDataTelemetry;
 import frc.robot.utilities.Telemetry;
@@ -75,13 +80,23 @@ public class RobotContainer {
     // Constructor
     // =====================================================================
     public RobotContainer() {
-        indexer = new IndexerSubsystem(new IndexerIOHardware());
-        intake = new IntakeSubsystem(new IntakeIOHardware());
-        shooter = new ShooterSubsystem(new ShooterIOHardware());
-        vision = new VisionSubsystem(
-            new VisionIOLimelight(Constants.Vision.LIMELIGHT4_NAME),
-            () -> drivetrain.getState().Pose.getRotation().getDegrees(),
-            () -> Math.toDegrees(drivetrain.getState().Speeds.omegaRadiansPerSecond));
+        if (RobotBase.isSimulation()) {
+            indexer = new IndexerSubsystem(new IndexerIOSim());
+            intake = new IntakeSubsystem(new IntakeIOSim());
+            shooter = new ShooterSubsystem(new ShooterIOSim());
+            vision = new VisionSubsystem(
+                new VisionIOSim(),
+                () -> drivetrain.getState().Pose.getRotation().getDegrees(),
+                () -> Math.toDegrees(drivetrain.getState().Speeds.omegaRadiansPerSecond));
+        } else {
+            indexer = new IndexerSubsystem(new IndexerIOHardware());
+            intake = new IntakeSubsystem(new IntakeIOHardware());
+            shooter = new ShooterSubsystem(new ShooterIOHardware());
+            vision = new VisionSubsystem(
+                new VisionIOLimelight(Constants.Vision.LIMELIGHT4_NAME),
+                () -> drivetrain.getState().Pose.getRotation().getDegrees(),
+                () -> Math.toDegrees(drivetrain.getState().Speeds.omegaRadiansPerSecond));
+        }
 
         autoFactory = drivetrain.createAutoFactory();
         autoRoutines = new AutoRoutines(autoFactory, drivetrain, indexer, intake, shooter, vision);

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerIOSim.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerIOSim.java
@@ -1,0 +1,73 @@
+package frc.robot.subsystems.indexer;
+
+/**
+ * IndexerIOSim - Simulation implementation of IndexerIO.
+ *
+ * Conveyor and kicker are modeled as first-order velocity filters.
+ * The chute CANrange sensor always reports no game piece; inject one via
+ * simulateGamePieceInChute() to test detection-dependent logic.
+ */
+public class IndexerIOSim implements IndexerIO {
+
+    // Motor state
+    private double conveyorTargetRPS = 0.0;
+    private double conveyorVelocityRPS = 0.0;
+    private double kickerTargetRPS = 0.0;
+    private double kickerVelocityRPS = 0.0;
+
+    // Sensor state — start with no game piece present
+    private boolean chuteDetected = false;
+
+    // First-order time constant for both motors
+    private static final double MOTOR_TC_SEC = 0.1;
+    // Rough RPS at 12V for voltage-based commands
+    private static final double MAX_RPS_AT_12V = 50.0;
+
+    private static final double DT = 0.02;
+
+    @Override
+    public void updateInputs(IndexerIOInputs inputs) {
+        double alpha = DT / MOTOR_TC_SEC;
+        conveyorVelocityRPS += alpha * (conveyorTargetRPS - conveyorVelocityRPS);
+        kickerVelocityRPS += alpha * (kickerTargetRPS - kickerVelocityRPS);
+
+        inputs.conveyorVelocityRPS = conveyorVelocityRPS;
+        inputs.conveyorCurrentAmps = Math.abs(conveyorVelocityRPS) * 0.5;
+        inputs.kickerLeadVelocityRPS = kickerVelocityRPS;
+        inputs.kickerLeadCurrentAmps = Math.abs(kickerVelocityRPS) * 0.5;
+        inputs.kickerFollowCurrentAmps = inputs.kickerLeadCurrentAmps;
+        inputs.chuteDistanceMeters = chuteDetected ? 0.05 : 1.0;
+        inputs.chuteDetected = chuteDetected;
+    }
+
+    @Override
+    public void setConveyorVelocity(double rps) {
+        conveyorTargetRPS = rps;
+    }
+
+    @Override
+    public void setConveyorMotor(double volts) {
+        conveyorTargetRPS = (volts / 12.0) * MAX_RPS_AT_12V;
+    }
+
+    @Override
+    public void setKickerVelocity(double rps) {
+        kickerTargetRPS = rps;
+    }
+
+    @Override
+    public void setKickerMotorVolts(double volts) {
+        kickerTargetRPS = (volts / 12.0) * MAX_RPS_AT_12V;
+    }
+
+    @Override
+    public void stop() {
+        conveyorTargetRPS = 0.0;
+        kickerTargetRPS = 0.0;
+    }
+
+    /** Call from test code or SmartDashboard to inject a simulated game piece. */
+    public void simulateGamePieceInChute(boolean present) {
+        chuteDetected = present;
+    }
+}

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
@@ -1,0 +1,77 @@
+package frc.robot.subsystems.intake;
+
+import frc.robot.Constants;
+
+/**
+ * IntakeIOSim - Simulation implementation of IntakeIO.
+ *
+ * Models the slide as a proportional position controller and the roller as a
+ * first-order velocity filter. No real hardware or CAN bus required.
+ */
+public class IntakeIOSim implements IntakeIO {
+
+    // Slide state
+    private double slidePositionRotations = 0.0;
+    private double slideTargetPosition = 0.0;
+
+    // Roller state
+    private double rollerTargetRPS = 0.0;
+    private double rollerVelocityRPS = 0.0;
+
+    // Slide P-gain: position error (rot) → velocity (RPS), clamped to cruise velocity
+    private static final double SLIDE_KP = 10.0;
+    private static final double SLIDE_MAX_VEL_RPS = Constants.Intake.SLIDE_MM_CRUISE_VELOCITY;
+
+    // Roller first-order time constant (seconds to approach setpoint)
+    private static final double ROLLER_TC_SEC = 0.1;
+
+    private static final double DT = 0.02;
+
+    @Override
+    public void updateInputs(IntakeIOInputs inputs) {
+        // Slide: proportional controller → velocity → integrate position
+        double posError = slideTargetPosition - slidePositionRotations;
+        double slideVelRPS = Math.max(-SLIDE_MAX_VEL_RPS, Math.min(SLIDE_MAX_VEL_RPS, posError * SLIDE_KP));
+        slidePositionRotations += slideVelRPS * DT;
+        // Clamp to physical travel limits (mirrors hardware soft limits)
+        slidePositionRotations = Math.max(0.0, Math.min(Constants.Intake.SLIDE_MAX_POS, slidePositionRotations));
+
+        // Roller: first-order filter toward target velocity
+        double alpha = DT / ROLLER_TC_SEC;
+        rollerVelocityRPS += alpha * (rollerTargetRPS - rollerVelocityRPS);
+
+        inputs.slidePositionRotations = slidePositionRotations;
+        inputs.slideVelocityRPS = slideVelRPS;
+    }
+
+    @Override
+    public void setRollerVelocity(double rps) {
+        rollerTargetRPS = rps;
+    }
+
+    @Override
+    public void stopRoller() {
+        rollerTargetRPS = 0.0;
+    }
+
+    @Override
+    public void setSlidePosition(double position) {
+        slideTargetPosition = position;
+    }
+
+    @Override
+    public void setSlidePositionSlow(double position) {
+        slideTargetPosition = position;
+    }
+
+    @Override
+    public void stopSlide() {
+        slideTargetPosition = slidePositionRotations;
+    }
+
+    @Override
+    public void resetSlideEncoder() {
+        slidePositionRotations = 0.0;
+        slideTargetPosition = 0.0;
+    }
+}

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOSim.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOSim.java
@@ -1,0 +1,93 @@
+package frc.robot.subsystems.shooter;
+
+import frc.robot.Constants;
+
+/**
+ * ShooterIOSim - Simulation implementation of ShooterIO.
+ *
+ * Flywheel is modeled as a first-order filter (spin-up lag).
+ * Hood is modeled as a proportional position controller.
+ * No real hardware or CAN bus required.
+ */
+public class ShooterIOSim implements ShooterIO {
+
+    // Flywheel state
+    private double flywheelTargetRPM = 0.0;
+    private double flywheelRPM = 0.0;
+
+    // Hood state
+    private double hoodTargetRotations = 0.0;
+    private double hoodPositionRotations = 0.0;
+
+    // Flywheel spin-up time constant (Kraken X60 reaches speed in ~400ms under load)
+    private static final double FLYWHEEL_TC_SEC = 0.4;
+    // Kraken X60 free-speed used to estimate applied volts
+    private static final double FLYWHEEL_FREE_SPEED_RPM = 6000.0;
+
+    // Hood P-gain: position error (rot) → velocity (RPS), clamped to max velocity
+    private static final double HOOD_KP = 15.0;
+    private static final double HOOD_MAX_VEL_RPS = Constants.Hood.CRUISE_VELOCITY;
+
+    private static final double DT = 0.02;
+
+    @Override
+    public void updateInputs(ShooterIOInputs inputs) {
+        // Flywheel: first-order filter toward target RPM
+        double alpha = DT / FLYWHEEL_TC_SEC;
+        flywheelRPM += alpha * (flywheelTargetRPM - flywheelRPM);
+
+        // Hood: proportional controller → velocity → integrate position
+        double hoodErr = hoodTargetRotations - hoodPositionRotations;
+        double hoodVel = Math.max(-HOOD_MAX_VEL_RPS, Math.min(HOOD_MAX_VEL_RPS, hoodErr * HOOD_KP));
+        hoodPositionRotations += hoodVel * DT;
+        hoodPositionRotations = Math.max(Constants.Hood.MIN_POSE, Math.min(Constants.Hood.MAX_POSE, hoodPositionRotations));
+
+        inputs.flywheelLeaderMotorRPM = flywheelRPM;
+        inputs.flywheelLeaderMotorRPS = flywheelRPM / 60.0;
+        inputs.flywheelAppliedVolts = (flywheelTargetRPM / FLYWHEEL_FREE_SPEED_RPM) * 12.0;
+        inputs.hoodPositionRotations = hoodPositionRotations;
+    }
+
+    @Override
+    public void updateSlowInputs(ShooterIOInputs inputs) {
+        inputs.flywheelCurrentAmps = Math.abs(flywheelRPM) / 100.0;
+        inputs.flywheelMaxTempCelsius = 25.0;
+        inputs.hoodAppliedVolts = 0.0;
+        inputs.hoodCurrentAmps = 0.0;
+    }
+
+    @Override
+    public void setFlywheelVelocity(double rpm) {
+        flywheelTargetRPM = rpm;
+    }
+
+    @Override
+    public void setFlywheelVelocityTorqueFOC(double rpm) {
+        flywheelTargetRPM = rpm;
+    }
+
+    @Override
+    public void stopFlywheels() {
+        flywheelTargetRPM = 0.0;
+    }
+
+    @Override
+    public void setHoodPose(double rawPosition) {
+        hoodTargetRotations = rawPosition;
+    }
+
+    @Override
+    public void setHoodVoltage(double volts) {
+        // Open-loop: scale voltage to velocity and integrate directly
+        double hoodVel = (volts / 12.0) * HOOD_MAX_VEL_RPS;
+        hoodPositionRotations += hoodVel * DT;
+        hoodPositionRotations = Math.max(Constants.Hood.MIN_POSE, Math.min(Constants.Hood.MAX_POSE, hoodPositionRotations));
+        hoodTargetRotations = hoodPositionRotations;
+    }
+
+    @Override
+    public void stop() {
+        flywheelTargetRPM = 0.0;
+        hoodTargetRotations = hoodPositionRotations;
+    }
+}

--- a/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionIOSim.java
@@ -1,0 +1,18 @@
+package frc.robot.subsystems.vision;
+
+/**
+ * VisionIOSim - Simulation implementation of VisionIO.
+ *
+ * Returns no vision targets. Prevents subsystems that depend on vision from
+ * crashing in simulation while keeping the pose-fusion path exercisable.
+ */
+public class VisionIOSim implements VisionIO {
+
+    @Override
+    public void updateInputs(VisionIOInputs inputs, double robotYawDegrees, double robotYawRateDegPerSec) {
+        inputs.megaTag2Valid = false;
+        inputs.megaTag1Valid = false;
+        inputs.hasTargets = false;
+        inputs.tagId = -1;
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds simulation-compatible IO implementations for the shooter, intake, indexer, and vision subsystems, enabling full simulation support without requiring hardware or CAN bus access. The `RobotContainer` is updated to conditionally instantiate simulation or hardware implementations based on the robot mode.

## Key Changes
- **ShooterIOSim**: Models flywheel as a first-order filter with ~400ms spin-up time constant and hood as a proportional position controller with velocity clamping
- **IntakeIOSim**: Models slide as a proportional position controller and roller as a first-order velocity filter with configurable time constants
- **IndexerIOSim**: Models conveyor and kicker motors as first-order velocity filters; includes `simulateGamePieceInChute()` method for test injection of game pieces
- **VisionIOSim**: Stub implementation that reports no vision targets, preventing crashes while keeping pose-fusion code exercisable
- **RobotContainer**: Added conditional logic using `RobotBase.isSimulation()` to instantiate appropriate IO implementations for each subsystem

## Notable Implementation Details
- All simulation motors use first-order filters with realistic time constants (0.1–0.4 seconds) to model spin-up/acceleration lag
- Hood and slide controllers use proportional gains with velocity clamping to prevent unrealistic motion
- Position limits are enforced (e.g., hood min/max pose, slide travel bounds) to mirror hardware constraints
- Voltage-based commands scale linearly to velocity using nominal 12V as reference
- Indexer chute sensor defaults to "no piece detected" but can be toggled via `simulateGamePieceInChute()` for testing detection logic

https://claude.ai/code/session_01Lnszbs1Xyq7vs79pxz4ehg