### PR TITLE
Back IOSim with real CTRE hardware so motors appear in Sim GUI

### DIFF
--- a/src/main/java/frc/robot/subsystems/indexer/IndexerIOSim.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerIOSim.java
@@ -1,73 +1,153 @@
 package frc.robot.subsystems.indexer;
 
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.Follower;
+import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.sim.TalonFXSimState;
+
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.math.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.simulation.DCMotorSim;
+
+import frc.robot.Constants;
+
 /**
  * IndexerIOSim - Simulation implementation of IndexerIO.
  *
- * Conveyor and kicker are modeled as first-order velocity filters.
- * The chute CANrange sensor always reports no game piece; inject one via
- * simulateGamePieceInChute() to test detection-dependent logic.
+ * Instantiates the conveyor + kicker leader/follower TalonFX objects so they
+ * appear in the Sim GUI, and drives leader rotors from DCMotorSim physics.
+ * The chute CANrange is not instantiated; chuteDetected is exposed as a
+ * software flag via simulateGamePieceInChute() for test injection.
  */
 public class IndexerIOSim implements IndexerIO {
 
-    // Motor state
-    private double conveyorTargetRPS = 0.0;
-    private double conveyorVelocityRPS = 0.0;
-    private double kickerTargetRPS = 0.0;
-    private double kickerVelocityRPS = 0.0;
+    private static final double LOOP_PERIOD_SEC = 0.020;
+    private static final DCMotor MOTOR_GEARBOX = DCMotor.getKrakenX60(1);
 
-    // Sensor state — start with no game piece present
+    private final TalonFX conveyor;
+    private final TalonFX kickerLeader;
+    private final TalonFX kickerFollower;
+
+    private final TalonFXSimState conveyorSim;
+    private final TalonFXSimState kickerLeaderSim;
+
+    private final DCMotorSim conveyorPlant;
+    private final DCMotorSim kickerPlant;
+
+    private final VelocityVoltage conveyorVelocityRequest =
+        new VelocityVoltage(0.0).withSlot(0).withEnableFOC(false);
+    private final VoltageOut conveyorVoltageRequest =
+        new VoltageOut(0.0).withEnableFOC(false);
+    private final VelocityVoltage kickerVelocityRequest =
+        new VelocityVoltage(0.0).withSlot(0).withEnableFOC(false);
+    private final VoltageOut kickerVoltageRequest =
+        new VoltageOut(0.0).withEnableFOC(false);
+
     private boolean chuteDetected = false;
 
-    // First-order time constant for both motors
-    private static final double MOTOR_TC_SEC = 0.1;
-    // Rough RPS at 12V for voltage-based commands
-    private static final double MAX_RPS_AT_12V = 50.0;
+    public IndexerIOSim() {
+        conveyor       = new TalonFX(Constants.Indexer.CONVEYOR_MOTOR_ID, Constants.RIO_CANBUS);
+        kickerLeader   = new TalonFX(Constants.Indexer.KICKER_LEFT_MOTOR_ID, Constants.RIO_CANBUS);
+        kickerFollower = new TalonFX(Constants.Indexer.KICKER_RIGHT_MOTOR_ID, Constants.RIO_CANBUS);
 
-    private static final double DT = 0.02;
+        conveyor.getConfigurator().apply(conveyorConfig());
+        kickerLeader.getConfigurator().apply(kickerLeaderConfig());
+        kickerFollower.getConfigurator().apply(kickerFollowerConfig());
+
+        kickerFollower.setControl(new Follower(
+            Constants.Indexer.KICKER_LEFT_MOTOR_ID,
+            Constants.Indexer.KickerFollowerConfig.FOLLOWER_ALIGNMENT));
+
+        conveyorSim = conveyor.getSimState();
+        kickerLeaderSim = kickerLeader.getSimState();
+
+        conveyorPlant = new DCMotorSim(
+            LinearSystemId.createDCMotorSystem(MOTOR_GEARBOX, 0.001, 1.0),
+            MOTOR_GEARBOX);
+        kickerPlant = new DCMotorSim(
+            LinearSystemId.createDCMotorSystem(MOTOR_GEARBOX, 0.001, 1.0),
+            MOTOR_GEARBOX);
+    }
 
     @Override
     public void updateInputs(IndexerIOInputs inputs) {
-        double alpha = DT / MOTOR_TC_SEC;
-        conveyorVelocityRPS += alpha * (conveyorTargetRPS - conveyorVelocityRPS);
-        kickerVelocityRPS += alpha * (kickerTargetRPS - kickerVelocityRPS);
+        stepPhysics(conveyorSim, conveyorPlant);
+        stepPhysics(kickerLeaderSim, kickerPlant);
 
-        inputs.conveyorVelocityRPS = conveyorVelocityRPS;
-        inputs.conveyorCurrentAmps = Math.abs(conveyorVelocityRPS) * 0.5;
-        inputs.kickerLeadVelocityRPS = kickerVelocityRPS;
-        inputs.kickerLeadCurrentAmps = Math.abs(kickerVelocityRPS) * 0.5;
-        inputs.kickerFollowCurrentAmps = inputs.kickerLeadCurrentAmps;
+        inputs.conveyorVelocityRPS = conveyor.getVelocity().getValueAsDouble();
+        inputs.conveyorCurrentAmps = conveyor.getSupplyCurrent().getValueAsDouble();
+        inputs.kickerLeadVelocityRPS = kickerLeader.getVelocity().getValueAsDouble();
+        inputs.kickerLeadCurrentAmps = kickerLeader.getSupplyCurrent().getValueAsDouble();
+        inputs.kickerFollowCurrentAmps = kickerFollower.getSupplyCurrent().getValueAsDouble();
+
         inputs.chuteDistanceMeters = chuteDetected ? 0.05 : 1.0;
         inputs.chuteDetected = chuteDetected;
     }
 
     @Override
     public void setConveyorVelocity(double rps) {
-        conveyorTargetRPS = rps;
+        conveyor.setControl(conveyorVelocityRequest.withVelocity(rps));
     }
 
     @Override
     public void setConveyorMotor(double volts) {
-        conveyorTargetRPS = (volts / 12.0) * MAX_RPS_AT_12V;
+        conveyor.setControl(conveyorVoltageRequest.withOutput(volts));
     }
 
     @Override
     public void setKickerVelocity(double rps) {
-        kickerTargetRPS = rps;
+        kickerLeader.setControl(kickerVelocityRequest.withVelocity(rps));
     }
 
     @Override
     public void setKickerMotorVolts(double volts) {
-        kickerTargetRPS = (volts / 12.0) * MAX_RPS_AT_12V;
+        kickerLeader.setControl(kickerVoltageRequest.withOutput(volts));
     }
 
     @Override
     public void stop() {
-        conveyorTargetRPS = 0.0;
-        kickerTargetRPS = 0.0;
+        conveyor.stopMotor();
+        kickerLeader.stopMotor();
     }
 
     /** Call from test code or SmartDashboard to inject a simulated game piece. */
     public void simulateGamePieceInChute(boolean present) {
         chuteDetected = present;
+    }
+
+    // == Helpers ==============================================================
+    private static void stepPhysics(TalonFXSimState simState, DCMotorSim plant) {
+        simState.setSupplyVoltage(RobotController.getBatteryVoltage());
+        plant.setInputVoltage(simState.getMotorVoltage());
+        plant.update(LOOP_PERIOD_SEC);
+        simState.setRawRotorPosition(plant.getAngularPositionRotations());
+        simState.setRotorVelocity(plant.getAngularVelocityRPM() / 60.0);
+    }
+
+    private static TalonFXConfiguration conveyorConfig() {
+        TalonFXConfiguration config = new TalonFXConfiguration();
+        config.MotorOutput.NeutralMode = Constants.Indexer.ConveyorConfig.NEUTRAL_MODE;
+        config.MotorOutput.Inverted = Constants.Indexer.ConveyorConfig.INVERTED;
+        config.Slot0.kV = Constants.Indexer.ConveyorConfig.SLOT0_KV;
+        config.Slot0.kP = Constants.Indexer.ConveyorConfig.SLOT0_KP;
+        return config;
+    }
+
+    private static TalonFXConfiguration kickerLeaderConfig() {
+        TalonFXConfiguration config = new TalonFXConfiguration();
+        config.MotorOutput.NeutralMode = Constants.Indexer.KickerLeaderConfig.NEUTRAL_MODE;
+        config.MotorOutput.Inverted = Constants.Indexer.KickerLeaderConfig.INVERTED;
+        config.Slot0.kV = Constants.Indexer.KickerLeaderConfig.SLOT0_KV;
+        config.Slot0.kP = Constants.Indexer.KickerLeaderConfig.SLOT0_KP;
+        return config;
+    }
+
+    private static TalonFXConfiguration kickerFollowerConfig() {
+        TalonFXConfiguration config = new TalonFXConfiguration();
+        config.MotorOutput.NeutralMode = Constants.Indexer.KickerFollowerConfig.NEUTRAL_MODE;
+        return config;
     }
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
@@ -1,77 +1,140 @@
 package frc.robot.subsystems.intake;
 
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.controls.MotionMagicVoltage;
+import com.ctre.phoenix6.controls.VelocityVoltage;
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.sim.TalonFXSimState;
+
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.math.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.simulation.DCMotorSim;
+
 import frc.robot.Constants;
 
 /**
  * IntakeIOSim - Simulation implementation of IntakeIO.
  *
- * Models the slide as a proportional position controller and the roller as a
- * first-order velocity filter. No real hardware or CAN bus required.
+ * Instantiates real CTRE TalonFX objects (so they appear in the WPILib Sim GUI)
+ * and drives their SimState from DCMotorSim physics models. The TalonFX runs its
+ * own closed-loop on the simulated rotor data, matching the production behavior.
  */
 public class IntakeIOSim implements IntakeIO {
 
-    // Slide state
-    private double slidePositionRotations = 0.0;
-    private double slideTargetPosition = 0.0;
+    private static final double LOOP_PERIOD_SEC = 0.020;
+    private static final DCMotor ROLLER_GEARBOX = DCMotor.getKrakenX60(1);
+    private static final DCMotor SLIDE_GEARBOX = DCMotor.getKrakenX60(1);
 
-    // Roller state
-    private double rollerTargetRPS = 0.0;
-    private double rollerVelocityRPS = 0.0;
+    private final TalonFX roller;
+    private final TalonFX slide;
 
-    // Slide P-gain: position error (rot) → velocity (RPS), clamped to cruise velocity
-    private static final double SLIDE_KP = 10.0;
-    private static final double SLIDE_MAX_VEL_RPS = Constants.Intake.SLIDE_MM_CRUISE_VELOCITY;
+    private final TalonFXSimState rollerSim;
+    private final TalonFXSimState slideSim;
 
-    // Roller first-order time constant (seconds to approach setpoint)
-    private static final double ROLLER_TC_SEC = 0.1;
+    private final DCMotorSim rollerPlant;
+    private final DCMotorSim slidePlant;
 
-    private static final double DT = 0.02;
+    private final VelocityVoltage rollerRequest = new VelocityVoltage(0.0).withSlot(0);
+    private final MotionMagicVoltage slideRequest = new MotionMagicVoltage(0.0).withSlot(0);
+
+    public IntakeIOSim() {
+        roller = new TalonFX(Constants.Intake.ROLLER_LEFT_MOTOR_ID, Constants.RIO_CANBUS);
+        slide  = new TalonFX(Constants.Intake.SLIDE_MOTOR_ID, Constants.RIO_CANBUS);
+
+        roller.getConfigurator().apply(rollerConfig());
+        slide.getConfigurator().apply(slideConfig());
+        slide.setPosition(0.0);
+
+        rollerSim = roller.getSimState();
+        slideSim  = slide.getSimState();
+
+        rollerPlant = new DCMotorSim(
+            LinearSystemId.createDCMotorSystem(ROLLER_GEARBOX, 0.001, 1.0),
+            ROLLER_GEARBOX);
+        slidePlant = new DCMotorSim(
+            LinearSystemId.createDCMotorSystem(SLIDE_GEARBOX, 0.025, 1.0),
+            SLIDE_GEARBOX);
+    }
 
     @Override
     public void updateInputs(IntakeIOInputs inputs) {
-        // Slide: proportional controller → velocity → integrate position
-        double posError = slideTargetPosition - slidePositionRotations;
-        double slideVelRPS = Math.max(-SLIDE_MAX_VEL_RPS, Math.min(SLIDE_MAX_VEL_RPS, posError * SLIDE_KP));
-        slidePositionRotations += slideVelRPS * DT;
-        // Clamp to physical travel limits (mirrors hardware soft limits)
-        slidePositionRotations = Math.max(0.0, Math.min(Constants.Intake.SLIDE_MAX_POS, slidePositionRotations));
+        stepPhysics(rollerSim, rollerPlant);
+        stepPhysics(slideSim, slidePlant);
 
-        // Roller: first-order filter toward target velocity
-        double alpha = DT / ROLLER_TC_SEC;
-        rollerVelocityRPS += alpha * (rollerTargetRPS - rollerVelocityRPS);
-
-        inputs.slidePositionRotations = slidePositionRotations;
-        inputs.slideVelocityRPS = slideVelRPS;
+        inputs.slidePositionRotations = slide.getPosition().getValueAsDouble();
+        inputs.slideVelocityRPS = slide.getVelocity().getValueAsDouble();
     }
 
     @Override
     public void setRollerVelocity(double rps) {
-        rollerTargetRPS = rps;
+        roller.setControl(rollerRequest.withVelocity(rps));
     }
 
     @Override
     public void stopRoller() {
-        rollerTargetRPS = 0.0;
+        roller.stopMotor();
     }
 
     @Override
     public void setSlidePosition(double position) {
-        slideTargetPosition = position;
+        slide.setControl(slideRequest.withPosition(position));
     }
 
     @Override
     public void setSlidePositionSlow(double position) {
-        slideTargetPosition = position;
+        slide.setControl(slideRequest.withPosition(position));
     }
 
     @Override
     public void stopSlide() {
-        slideTargetPosition = slidePositionRotations;
+        slide.stopMotor();
     }
 
     @Override
     public void resetSlideEncoder() {
-        slidePositionRotations = 0.0;
-        slideTargetPosition = 0.0;
+        slide.setPosition(0.0);
+        slidePlant.setState(0.0, 0.0);
+    }
+
+    // == Helpers ==============================================================
+    private static void stepPhysics(TalonFXSimState simState, DCMotorSim plant) {
+        simState.setSupplyVoltage(RobotController.getBatteryVoltage());
+        plant.setInputVoltage(simState.getMotorVoltage());
+        plant.update(LOOP_PERIOD_SEC);
+        simState.setRawRotorPosition(plant.getAngularPositionRotations());
+        simState.setRotorVelocity(plant.getAngularVelocityRPM() / 60.0);
+    }
+
+    private static TalonFXConfiguration rollerConfig() {
+        TalonFXConfiguration config = new TalonFXConfiguration();
+        config.MotorOutput.NeutralMode = Constants.Intake.RollerLeaderConfig.NEUTRAL_MODE;
+        config.Slot0.kS = Constants.Intake.RollerLeaderConfig.KS;
+        config.Slot0.kV = Constants.Intake.RollerLeaderConfig.KV;
+        config.Slot0.kP = Constants.Intake.RollerLeaderConfig.KP;
+        return config;
+    }
+
+    private static TalonFXConfiguration slideConfig() {
+        TalonFXConfiguration config = new TalonFXConfiguration();
+        config.MotorOutput.NeutralMode = Constants.Intake.SlideConfig.NEUTRAL_MODE;
+
+        config.SoftwareLimitSwitch.ForwardSoftLimitEnable = true;
+        config.SoftwareLimitSwitch.ForwardSoftLimitThreshold = Constants.Intake.SLIDE_MAX_POS;
+        config.SoftwareLimitSwitch.ReverseSoftLimitEnable = true;
+        config.SoftwareLimitSwitch.ReverseSoftLimitThreshold = Constants.Intake.SlideConfig.REVERSE_SOFT_LIMIT;
+
+        config.Slot0.kP = Constants.Intake.SlideConfig.KP;
+        config.Slot0.kI = Constants.Intake.SlideConfig.KI;
+        config.Slot0.kD = Constants.Intake.SlideConfig.KD;
+        config.Slot0.kS = Constants.Intake.SlideConfig.KS;
+        config.Slot0.kV = Constants.Intake.SlideConfig.KV;
+        config.Slot0.kA = Constants.Intake.SlideConfig.KA;
+
+        config.MotionMagic.MotionMagicCruiseVelocity = Constants.Intake.SLIDE_MM_CRUISE_VELOCITY;
+        config.MotionMagic.MotionMagicAcceleration = Constants.Intake.SLIDE_MM_ACCELERATION;
+        config.MotionMagic.MotionMagicJerk = Constants.Intake.SLIDE_MM_JERK;
+
+        return config;
     }
 }

--- a/src/main/java/frc/robot/subsystems/shooter/ShooterIOSim.java
+++ b/src/main/java/frc/robot/subsystems/shooter/ShooterIOSim.java
@@ -1,93 +1,182 @@
 package frc.robot.subsystems.shooter;
 
+import com.ctre.phoenix6.configs.TalonFXConfiguration;
+import com.ctre.phoenix6.configs.TalonFXSConfiguration;
+import com.ctre.phoenix6.controls.Follower;
+import com.ctre.phoenix6.controls.MotionMagicVelocityVoltage;
+import com.ctre.phoenix6.controls.PositionVoltage;
+import com.ctre.phoenix6.controls.VoltageOut;
+import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.hardware.TalonFXS;
+import com.ctre.phoenix6.sim.TalonFXSSimState;
+import com.ctre.phoenix6.sim.TalonFXSimState;
+
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.math.system.plant.LinearSystemId;
+import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.simulation.DCMotorSim;
+import edu.wpi.first.wpilibj.simulation.FlywheelSim;
+
 import frc.robot.Constants;
 
 /**
  * ShooterIOSim - Simulation implementation of ShooterIO.
  *
- * Flywheel is modeled as a first-order filter (spin-up lag).
- * Hood is modeled as a proportional position controller.
- * No real hardware or CAN bus required.
+ * Instantiates real CTRE flywheel + hood hardware so they appear in the Sim GUI,
+ * then drives their SimState from FlywheelSim (flywheel) and DCMotorSim (hood)
+ * physics models. The follower flywheel is wired but its rotor state is not driven.
  */
 public class ShooterIOSim implements ShooterIO {
 
-    // Flywheel state
-    private double flywheelTargetRPM = 0.0;
-    private double flywheelRPM = 0.0;
+    private static final double LOOP_PERIOD_SEC = 0.020;
+    private static final DCMotor FLYWHEEL_GEARBOX = DCMotor.getKrakenX60(2);
+    // Hood is a Minion via TalonFXS; getKrakenX60 is used as a stand-in DC model for sim.
+    private static final DCMotor HOOD_GEARBOX = DCMotor.getKrakenX60(1);
 
-    // Hood state
-    private double hoodTargetRotations = 0.0;
-    private double hoodPositionRotations = 0.0;
+    private final TalonFX flywheelLeader;
+    private final TalonFX flywheelFollower;
+    private final TalonFXS hood;
 
-    // Flywheel spin-up time constant (Kraken X60 reaches speed in ~400ms under load)
-    private static final double FLYWHEEL_TC_SEC = 0.4;
-    // Kraken X60 free-speed used to estimate applied volts
-    private static final double FLYWHEEL_FREE_SPEED_RPM = 6000.0;
+    private final TalonFXSimState flywheelLeaderSim;
+    private final TalonFXSSimState hoodSim;
 
-    // Hood P-gain: position error (rot) → velocity (RPS), clamped to max velocity
-    private static final double HOOD_KP = 15.0;
-    private static final double HOOD_MAX_VEL_RPS = Constants.Hood.CRUISE_VELOCITY;
+    private final FlywheelSim flywheelPlant;
+    private final DCMotorSim hoodPlant;
 
-    private static final double DT = 0.02;
+    private final MotionMagicVelocityVoltage flywheelRequest =
+        new MotionMagicVelocityVoltage(0.0).withEnableFOC(false);
+    private final PositionVoltage hoodPositionRequest =
+        new PositionVoltage(0.0).withEnableFOC(false);
+    private final VoltageOut hoodVoltageRequest =
+        new VoltageOut(0.0).withEnableFOC(false);
+
+    public ShooterIOSim() {
+        flywheelLeader   = new TalonFX(Constants.Flywheel.FLYWHEEL_LEFT_MOTOR_ID, Constants.RIO_CANBUS);
+        flywheelFollower = new TalonFX(Constants.Flywheel.FLYWHEEL_RIGHT_MOTOR_ID, Constants.RIO_CANBUS);
+        hood = new TalonFXS(Constants.Hood.HOOD_MOTOR_ID, Constants.RIO_CANBUS);
+
+        flywheelLeader.getConfigurator().apply(flywheelLeaderConfig());
+        flywheelFollower.getConfigurator().apply(flywheelFollowerConfig());
+        hood.getConfigurator().apply(hoodConfig());
+
+        // Wire follower so it appears in the GUI mirroring the leader's command
+        flywheelFollower.setControl(new Follower(
+            Constants.Flywheel.FLYWHEEL_LEFT_MOTOR_ID,
+            Constants.Flywheel.FollowerConfig.FOLLOWER_ALIGNMENT));
+
+        hood.setPosition(Constants.Hood.ENCODER_ZERO_POSITION);
+
+        flywheelLeaderSim = flywheelLeader.getSimState();
+        hoodSim = hood.getSimState();
+
+        flywheelPlant = new FlywheelSim(
+            LinearSystemId.createFlywheelSystem(FLYWHEEL_GEARBOX, 0.005, 1.0),
+            FLYWHEEL_GEARBOX);
+        hoodPlant = new DCMotorSim(
+            LinearSystemId.createDCMotorSystem(HOOD_GEARBOX, 0.004, 1.0),
+            HOOD_GEARBOX);
+    }
 
     @Override
     public void updateInputs(ShooterIOInputs inputs) {
-        // Flywheel: first-order filter toward target RPM
-        double alpha = DT / FLYWHEEL_TC_SEC;
-        flywheelRPM += alpha * (flywheelTargetRPM - flywheelRPM);
+        // Flywheel physics: FlywheelSim is velocity-only — no rotor position to set.
+        flywheelLeaderSim.setSupplyVoltage(RobotController.getBatteryVoltage());
+        flywheelPlant.setInputVoltage(flywheelLeaderSim.getMotorVoltage());
+        flywheelPlant.update(LOOP_PERIOD_SEC);
+        flywheelLeaderSim.setRotorVelocity(flywheelPlant.getAngularVelocityRPM() / 60.0);
 
-        // Hood: proportional controller → velocity → integrate position
-        double hoodErr = hoodTargetRotations - hoodPositionRotations;
-        double hoodVel = Math.max(-HOOD_MAX_VEL_RPS, Math.min(HOOD_MAX_VEL_RPS, hoodErr * HOOD_KP));
-        hoodPositionRotations += hoodVel * DT;
-        hoodPositionRotations = Math.max(Constants.Hood.MIN_POSE, Math.min(Constants.Hood.MAX_POSE, hoodPositionRotations));
+        // Hood physics
+        hoodSim.setSupplyVoltage(RobotController.getBatteryVoltage());
+        hoodPlant.setInputVoltage(hoodSim.getMotorVoltage());
+        hoodPlant.update(LOOP_PERIOD_SEC);
+        hoodSim.setRawRotorPosition(hoodPlant.getAngularPositionRotations());
+        hoodSim.setRotorVelocity(hoodPlant.getAngularVelocityRPM() / 60.0);
 
-        inputs.flywheelLeaderMotorRPM = flywheelRPM;
-        inputs.flywheelLeaderMotorRPS = flywheelRPM / 60.0;
-        inputs.flywheelAppliedVolts = (flywheelTargetRPM / FLYWHEEL_FREE_SPEED_RPM) * 12.0;
-        inputs.hoodPositionRotations = hoodPositionRotations;
+        double motorRPS = flywheelLeader.getVelocity().getValueAsDouble();
+        inputs.flywheelLeaderMotorRPS = motorRPS;
+        inputs.flywheelLeaderMotorRPM = motorRPS * 60.0;
+        inputs.flywheelAppliedVolts = flywheelLeader.getMotorVoltage().getValueAsDouble();
+        inputs.hoodPositionRotations = hood.getPosition().getValueAsDouble();
     }
 
     @Override
     public void updateSlowInputs(ShooterIOInputs inputs) {
-        inputs.flywheelCurrentAmps = Math.abs(flywheelRPM) / 100.0;
+        inputs.flywheelCurrentAmps = flywheelLeader.getSupplyCurrent().getValueAsDouble();
         inputs.flywheelMaxTempCelsius = 25.0;
-        inputs.hoodAppliedVolts = 0.0;
-        inputs.hoodCurrentAmps = 0.0;
+        inputs.hoodAppliedVolts = hood.getMotorVoltage().getValueAsDouble();
+        inputs.hoodCurrentAmps = hood.getSupplyCurrent().getValueAsDouble();
     }
 
     @Override
     public void setFlywheelVelocity(double rpm) {
-        flywheelTargetRPM = rpm;
+        flywheelLeader.setControl(flywheelRequest.withVelocity(rpm / 60.0));
     }
 
     @Override
     public void setFlywheelVelocityTorqueFOC(double rpm) {
-        flywheelTargetRPM = rpm;
+        flywheelLeader.setControl(flywheelRequest.withVelocity(rpm / 60.0));
     }
 
     @Override
     public void stopFlywheels() {
-        flywheelTargetRPM = 0.0;
+        flywheelLeader.stopMotor();
     }
 
     @Override
     public void setHoodPose(double rawPosition) {
-        hoodTargetRotations = rawPosition;
+        hood.setControl(hoodPositionRequest.withPosition(rawPosition));
     }
 
     @Override
     public void setHoodVoltage(double volts) {
-        // Open-loop: scale voltage to velocity and integrate directly
-        double hoodVel = (volts / 12.0) * HOOD_MAX_VEL_RPS;
-        hoodPositionRotations += hoodVel * DT;
-        hoodPositionRotations = Math.max(Constants.Hood.MIN_POSE, Math.min(Constants.Hood.MAX_POSE, hoodPositionRotations));
-        hoodTargetRotations = hoodPositionRotations;
+        hood.setControl(hoodVoltageRequest.withOutput(volts));
     }
 
     @Override
     public void stop() {
-        flywheelTargetRPM = 0.0;
-        hoodTargetRotations = hoodPositionRotations;
+        flywheelLeader.stopMotor();
+        hood.stopMotor();
+    }
+
+    // == Configs (subset — closed-loop + soft limits) ========================
+    private static TalonFXConfiguration flywheelLeaderConfig() {
+        TalonFXConfiguration config = new TalonFXConfiguration();
+        config.MotorOutput.NeutralMode = Constants.Flywheel.LeaderConfig.NEUTRAL_MODE;
+        config.MotorOutput.Inverted = Constants.Flywheel.LeaderConfig.INVERTED;
+
+        config.MotionMagic.MotionMagicAcceleration = Constants.Flywheel.MM_ACCELERATION_RPS_PER_SEC;
+        config.MotionMagic.MotionMagicJerk = Constants.Flywheel.MM_JERK_RPS_PER_SEC_CUBED;
+
+        config.Slot0.kP = Constants.Flywheel.KP;
+        config.Slot0.kV = Constants.Flywheel.KV;
+        config.Slot0.kA = Constants.Flywheel.KA;
+        config.Slot0.kD = Constants.Flywheel.KD;
+        return config;
+    }
+
+    private static TalonFXConfiguration flywheelFollowerConfig() {
+        TalonFXConfiguration config = new TalonFXConfiguration();
+        config.MotorOutput.NeutralMode = Constants.Flywheel.FollowerConfig.NEUTRAL_MODE;
+        return config;
+    }
+
+    private static TalonFXSConfiguration hoodConfig() {
+        TalonFXSConfiguration config = new TalonFXSConfiguration();
+        config.Commutation.MotorArrangement = Constants.Hood.HoodConfig.MOTOR_ARRANGEMENT;
+        config.MotorOutput.NeutralMode = Constants.Hood.HoodConfig.NEUTRAL_MODE;
+        config.MotorOutput.Inverted = Constants.Hood.HoodConfig.INVERTED;
+
+        config.Voltage.PeakForwardVoltage = Constants.Hood.PEAK_FORWARD_VOLTAGE;
+        config.Voltage.PeakReverseVoltage = Constants.Hood.PEAK_REVERSE_VOLTAGE;
+
+        config.Slot0.kP = Constants.Hood.KP;
+        config.Slot0.kI = Constants.Hood.KI;
+        config.Slot0.kD = Constants.Hood.KD;
+
+        config.SoftwareLimitSwitch.ForwardSoftLimitEnable = true;
+        config.SoftwareLimitSwitch.ForwardSoftLimitThreshold = Constants.Hood.MAX_POSE;
+        config.SoftwareLimitSwitch.ReverseSoftLimitEnable = true;
+        config.SoftwareLimitSwitch.ReverseSoftLimitThreshold = Constants.Hood.MIN_POSE;
+        return config;
     }
 }


### PR DESCRIPTION
The original IOSim classes used pure-math models that bypassed CTRE entirely, so nothing registered with the WPILib Sim GUI. Each IOSim now instantiates the same TalonFX/TalonFXS objects as IOHardware (with closed-loop configs applied) and drives their SimState from WPILib DCMotorSim/FlywheelSim physics.

Followers are wired so they also appear in the GUI; only leader rotors are driven by physics. Indexer chute detection stays a software flag injectable via simulateGamePieceInChute().

https://claude.ai/code/session_01Lnszbs1Xyq7vs79pxz4ehg